### PR TITLE
add OWNERS_ALIASES for knative-eventing

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
 approvers:
-- evankanderson
-- grantr
-- inlined
-- scothis
-- vaikas-google
+- eventing-approvers
+
+reviewers:
+- eventing-reviewers
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,23 @@
+aliases:
+  eventing-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - bbrowning
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
+  eventing-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - bbrowning
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni


### PR DESCRIPTION
This PR adds OWNERS_ALIASES for knative-eventing similar way as for [knative-serving](https://github.com/openshift/knative-serving/blob/master/OWNERS_ALIASES).