### PR TITLE
Run kubecon demo as part of e2e tests

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,6 +1,7 @@
 #!/bin/sh 
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+source $(dirname $0)/kubecon-demo.sh
 
 set -x
 
@@ -228,6 +229,7 @@ function delete_in_memory_channel_provisioner(){
 }
 
 function teardown() {
+  delete_demo
   delete_test_namespace
   delete_in_memory_channel_provisioner
   delete_knative_eventing
@@ -272,6 +274,12 @@ create_test_namespace
 
 create_test_resources
 
-run_e2e_tests || fail_test
+failed=0
+
+run_e2e_tests || failed=1
+
+run_demo || failed=1
+
+(( failed )) && fail_test
 
 success

--- a/openshift/kubecon-demo.sh
+++ b/openshift/kubecon-demo.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+readonly DEMO_URL="https://raw.githubusercontent.com/openshift-cloud-functions/demos/master/knative-kubecon"
+
+function run_demo(){
+  header "Running Knative Build/Serving/Eventing Demo"
+  
+  oc import-image -n openshift golang --from=centos/go-toolset-7-centos7 --confirm
+  oc import-image -n openshift golang:1.11 --from=centos/go-toolset-7-centos7 --confirm
+  
+  oc new-project myproject
+
+  oc adm policy add-cluster-role-to-user cluster-admin -z default -n myproject
+  oc adm policy add-scc-to-user anyuid -z default -n myproject
+  oc adm policy add-scc-to-user privileged -z default -n myproject
+
+  apply build/000-rolebinding.yaml
+  apply eventing/000-rolebinding.yaml
+  
+  apply build/010-build-template.yaml
+  apply serving/010-service.yaml
+
+  wait_for_all_pods myproject    
+
+  local ip=$(oc get svc knative-ingressgateway -n istio-system -o 'jsonpath={.status.loadBalancer.ingress[0].ip}')
+  local port=$(oc get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+  
+  # Check that the helloworld app can server requests
+  curl -H "Host: helloworld-openshift.myproject.example.com" "http://${ip}:${port}/health" || return 1
+
+  apply eventing/010-channel.yaml
+  apply eventing/020-k8s-event-source.yaml
+  apply eventing/030-subscription.yaml
+
+  wait_for_all_pods myproject  
+  
+  kubectl run busybox --image=busybox --restart=Never -- sh
+
+  # Check that events arrive at the application
+  wait_for_logged_events
+}
+
+function apply(){
+  local yaml_path=$1
+  curl -L ${DEMO_URL}/${yaml_path} | oc apply -f -
+}
+
+function delete(){
+  local yaml_path=$1
+  curl -L ${DEMO_URL}/${yaml_path} | oc delete -f -
+}
+
+function delete_demo(){
+  delete build/000-rolebinding.yaml
+  delete eventing/000-rolebinding.yaml
+  oc delete project myproject
+}
+
+function wait_for_all_pods {
+  timeout 300 "oc get pods -n $1 2>&1 | grep -v -E '(Running|Completed|STATUS)'"
+}
+
+function wait_for_logged_events(){
+  POD=$(oc get pods | grep helloworld-openshift-00001-deployment | awk '{ print $1 }')
+  timeout 300 "oc logs $POD -c user-container | grep -E \"Ce-Source: .*pods/busybox\""
+}
+
+function timeout() {
+  SECONDS=0; TIMEOUT=$1; shift
+  while eval $*; do
+    sleep 5
+    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && exit -1
+  done
+}


### PR DESCRIPTION
knative build/serving/eventing are pre-installed by CI before running the demo. Eventing is installed from sources, build and serving are installed as dependencies of eventing. The scripts do not use OLM.