### PR TITLE
Wait longer for the dumpy deployment to go down

### DIFF
--- a/openshift/kubecon-demo.sh
+++ b/openshift/kubecon-demo.sh
@@ -85,7 +85,7 @@ function wait_for_redhat(){
 }
 
 function wait_for_dumpy_00001_to_shutdown(){
-  timeout 180 "! oc get pods | grep dumpy-00001-deployment"
+  timeout 360 "! oc get pods | grep dumpy-00001-deployment"
 }
 
 function check_no_dumpy_00001(){


### PR DESCRIPTION
* the default scale-to-zero period is 5 mins

The nightly job currently fails, this is the attempt to fix it (https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/periodic-ci-openshift-knative-eventing-release-0.2-e2e/30)