### PR TITLE
Generate Dockerfiles via script - release-0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,25 @@
 
 CGO_ENABLED=0
 GOOS=linux
+CORE_IMAGES=./cmd/controller/ ./cmd/webhook/ ./pkg/provisioners/kafka ./cmd/fanoutsidecar
+TEST_IMAGES=./test/test_images/k8sevents
 
 install:
-	go install ./cmd/controller/ ./cmd/webhook/ ./pkg/provisioners/kafka ./cmd/fanoutsidecar
+	go install $(CORE_IMAGES)
 	go build -o $(GOPATH)/bin/in-memory-channel-controller ./pkg/controller/eventing/inmemory/controller
 .PHONY: install
 
 test-install:
-	go install ./test/test_images/k8sevents
+	go install $(TEST_IMAGES)
 .PHONY: test-install
 
 test-e2e:
 	sh openshift/e2e-tests-openshift.sh
 .PHONY: test-e2e
+
+# Generate Dockerfiles used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images in-memory-channel-controller
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+.PHONY: generate-dockerfiles

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
 FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
-ADD kafka /usr/bin/kafka
-ENTRYPOINT ["/usr/bin/kafka"]
+ADD ${bin} /usr/bin/${bin}
+ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+function generate_dockefiles() {
+  local target_dir=$1; shift
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/ci-operator/knative-images/fanoutsidecar/Dockerfile
+++ b/openshift/ci-operator/knative-images/fanoutsidecar/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD fanoutsidecar /usr/bin/fanoutsidecar
 ENTRYPOINT ["/usr/bin/fanoutsidecar"]

--- a/openshift/ci-operator/knative-images/in-memory-channel-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/in-memory-channel-controller/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD in-memory-channel-controller /usr/bin/in-memory-channel-controller
 ENTRYPOINT ["/usr/bin/in-memory-channel-controller"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD webhook /usr/bin/webhook
 ENTRYPOINT ["/usr/bin/webhook"]

--- a/openshift/ci-operator/knative-test-images/k8sevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/k8sevents/Dockerfile
@@ -1,5 +1,5 @@
-FROM gcr.io/distroless/base:latest
-LABEL maintainer="mgencur@redhat.com"
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
 
 ADD k8sevents /usr/bin/k8sevents
 ENTRYPOINT ["/usr/bin/k8sevents"]


### PR DESCRIPTION
Use registry.svc.ci.openshift.org/openshift/origin-v3.11:base as the
base image. The FROM clause is ignored by ci-operator during the actual
build and is replaced by an image from ci-operator's config. Anyway,
it's replaced with the same image name so here we only make sure the
user knows what the base image is.
(this update comes after this change: openshift/release@7da82d8 )
