### PR TITLE
Release yaml master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,8 @@ generate-dockerfiles:
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images in-memory-channel-controller
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
 .PHONY: generate-dockerfiles
+
+# Generate an aggregated knative yaml file with replaced image references
+generate-release:
+	./openshift/release/generate-release.sh $(RELEASE)
+.PHONY: generate-release

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,6 +1,7 @@
 #!/bin/sh 
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+source $(dirname $0)/release/resolve.sh
 
 set -x
 
@@ -25,7 +26,8 @@ readonly TEST_ORIGIN_CONFORMANCE="${TEST_ORIGIN_CONFORMANCE:-"false"}"
 readonly SERVING_NAMESPACE=knative-serving
 readonly EVENTING_NAMESPACE=knative-eventing
 readonly TEST_NAMESPACE=e2etest
-readonly TEST_FUNCTION_NAMESPACE=e2etestfn3
+readonly TEST_FUNCTION_NAMESPACE=e2etest-knative-eventing
+readonly TARGET_IMAGE_PREFIX="$INTERNAL_REGISTRY/$EVENTING_NAMESPACE/knative-eventing-"
 
 env
 
@@ -148,7 +150,10 @@ function install_knative_eventing(){
   oc adm policy add-scc-to-user anyuid -z in-memory-channel-dispatcher -n $EVENTING_NAMESPACE
   oc adm policy add-scc-to-user anyuid -z in-memory-channel-controller -n $EVENTING_NAMESPACE
 
-  resolve_resources config/ $EVENTING_NAMESPACE eventing-resolved.yaml
+  resolve_resources config/ eventing-resolved.yaml $TARGET_IMAGE_PREFIX
+
+  tag_core_images eventing-resolved.yaml
+
   oc apply -f eventing-resolved.yaml
 
   oc adm policy add-cluster-role-to-user cluster-admin -z eventing-controller -n $EVENTING_NAMESPACE
@@ -164,7 +169,10 @@ function install_knative_eventing(){
 
 function install_in_memory_channel_provisioner(){
   header "Standing up In-Memory ClusterChannelProvisioner"
-  resolve_resources config/provisioners/in-memory-channel/ $EVENTING_NAMESPACE channel-resolved.yaml
+  resolve_resources config/provisioners/in-memory-channel/ channel-resolved.yaml $TARGET_IMAGE_PREFIX
+
+  tag_core_images channel-resolved.yaml
+
   oc apply -f channel-resolved.yaml
 }
 
@@ -189,17 +197,8 @@ function create_test_resources() {
   oc adm policy add-scc-to-user privileged -z e2e-receive-adapter -n $TEST_FUNCTION_NAMESPACE
 }
 
-function resolve_resources(){
-  local dir=$1
-  local resolved_file_name=$3
-  > $resolved_file_name
-  for yaml in $(find $dir -maxdepth 1 -name "*.yaml"); do
-    echo "---" >> $resolved_file_name
-    #first prefix all test images with "test-", then replace all image names with proper repository
-    sed -e 's/\(.* image: \)\(github.com\)\(.*\/\)\(test\/\)\(.*\)/\1\2 \3\4test-\5/' $yaml | \
-    sed -e 's%github.com/knative/eventing/pkg/provisioners/inmemory/controller%'"$INTERNAL_REGISTRY"'\/'"$EVENTING_NAMESPACE"'\/knative-eventing-in-memory-channel-controller%' | \
-    sed -e 's/\(.* image: \)\(github.com\)\(.*\/\)\(.*\)/\1 '"$INTERNAL_REGISTRY"'\/'"$EVENTING_NAMESPACE"'\/knative-eventing-\4/' >> $resolved_file_name
-  done
+function tag_core_images(){
+  local resolved_file_name=$1
 
   oc policy add-role-to-group system:image-puller system:serviceaccounts:${EVENTING_NAMESPACE} --namespace=${OPENSHIFT_BUILD_NAMESPACE}
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -197,7 +197,7 @@ function resolve_resources(){
     echo "---" >> $resolved_file_name
     #first prefix all test images with "test-", then replace all image names with proper repository
     sed -e 's/\(.* image: \)\(github.com\)\(.*\/\)\(test\/\)\(.*\)/\1\2 \3\4test-\5/' $yaml | \
-    sed -e 's%github.com/knative/eventing/pkg/controller/eventing/inmemory/controller%'"$INTERNAL_REGISTRY"'\/'"$EVENTING_NAMESPACE"'\/knative-eventing-in-memory-channel-controller%' | \
+    sed -e 's%github.com/knative/eventing/pkg/provisioners/inmemory/controller%'"$INTERNAL_REGISTRY"'\/'"$EVENTING_NAMESPACE"'\/knative-eventing-in-memory-channel-controller%' | \
     sed -e 's/\(.* image: \)\(github.com\)\(.*\/\)\(.*\)/\1 '"$INTERNAL_REGISTRY"'\/'"$EVENTING_NAMESPACE"'\/knative-eventing-\4/' >> $resolved_file_name
   done
 
@@ -206,7 +206,7 @@ function resolve_resources(){
   echo ">> Creating imagestream tags for images referenced in yaml files"
   IMAGE_NAMES=$(cat $resolved_file_name | grep -i "image:" | grep "$INTERNAL_REGISTRY" | awk '{print $2}' | awk -F '/' '{print $3}')
   for name in $IMAGE_NAMES; do
-    tag_built_image ${name} ${name}
+    tag_built_image ${name} ${name} "latest"
   done
 }
 
@@ -298,14 +298,16 @@ function tag_test_images() {
 
   for image_dir in ${image_dirs}; do
     name=$(basename ${image_dir})
-    tag_built_image knative-eventing-test-${name} ${name}
+    tag_built_image knative-eventing-test-${name} ${name} "e2e"
+
   done
 }
 
 function tag_built_image() {
   local remote_name=$1
   local local_name=$2
-  oc tag --insecure=${INSECURE} -n ${EVENTING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:${remote_name} ${local_name}:latest
+  local build_tag=$3
+  oc tag --insecure=${INSECURE} -n ${EVENTING_NAMESPACE} ${OPENSHIFT_REGISTRY}/${OPENSHIFT_BUILD_NAMESPACE}/stable:${remote_name} ${local_name}:${build_tag}
 }
 
 function run_origin_e2e() {

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -206,7 +206,7 @@ function resolve_resources(){
   echo ">> Creating imagestream tags for images referenced in yaml files"
   IMAGE_NAMES=$(cat $resolved_file_name | grep -i "image:" | grep "$INTERNAL_REGISTRY" | awk '{print $2}' | awk -F '/' '{print $3}')
   for name in $IMAGE_NAMES; do
-    tag_built_image ${name} ${name} "latest"
+    tag_built_image ${name} ${name} latest
   done
 }
 
@@ -298,7 +298,7 @@ function tag_test_images() {
 
   for image_dir in ${image_dirs}; do
     name=$(basename ${image_dir})
-    tag_built_image knative-eventing-test-${name} ${name} "e2e"
+    tag_built_image knative-eventing-test-${name} ${name} e2e
 
   done
 }

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -13,5 +13,6 @@ git checkout -b "$target" "$release"
 git fetch openshift master
 git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
+make RELEASE=$release generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/resolve.sh
+
+release=$1
+
+quay_image_prefix="quay.io/openshift-knative/knative-eventing-"
+output_file="openshift/release/knative-eventing-${release}.yaml"
+
+resolve_resources config/ $output_file $quay_image_prefix $release
+resolve_resources config/provisioners/in-memory-channel/ channel-resolved.yaml $quay_image_prefix $release
+cat channel-resolved.yaml >> $output_file

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+function resolve_resources(){
+  local dir=$1
+  local resolved_file_name=$2
+  local image_prefix=$3
+  local image_tag=$4
+
+  [[ -n $image_tag ]] && image_tag=":$image_tag"
+
+  echo "Writing resolved yaml to $resolved_file_name"
+
+  > $resolved_file_name
+
+  for yaml in "$dir"/*.yaml; do
+    echo "---" >> $resolved_file_name
+    # 1. Prefix test image references with test-
+    # 2. Rewrite inmemory controller image reference separately
+    # 3. Rewrite image references
+    # 4. Remove comment lines
+    # 5. Remove empty lines
+    sed -e "s+\(.* image: \)\(github.com\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
+        -e "s+github.com/knative/eventing/pkg/provisioners/inmemory/controller+${image_prefix}in-memory-channel-controller${image_tag}+" \
+        -e "s+\(.* image: \)\(github.com\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
+        -e '/^[ \t]*#/d' \
+        -e '/^[ \t]*$/d' \
+        "$yaml" >> $resolved_file_name
+  done
+}


### PR DESCRIPTION
Same as https://github.com/openshift/knative-eventing/pull/47 but the resulting release yaml file is not included (this is a master branch where we don't want that).

I've also included some test fixes from release-v0.5.0 branch so that the scripts are up-to-date for a new branch.

