### PR TITLE
remove files from release generation

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -12,7 +12,9 @@ resolve_resources config/ $output_file $quay_image_prefix $release
 # in-memory-channel
 resolve_resources config/provisioners/in-memory-channel/ channel-resolved.yaml $quay_image_prefix $release
 cat channel-resolved.yaml >> $output_file
+rm channel-resolved.yaml
 
 # Apache Kafka channel
-#resolve_resources contrib/kafka/config/ kafka-resolved.yaml $quay_image_prefix $release
-#cat kafka-resolved.yaml >> $output_file
+# resolve_resources contrib/kafka/config/ kafka-resolved.yaml $quay_image_prefix $release
+# cat kafka-resolved.yaml >> $output_file
+# rm kafka-resolved.yaml


### PR DESCRIPTION
During the release process, we use different input files, and pipe them to a larger "release" file.

after the "release" yaml file has reached final state, let's remove the bits that are not really needed 