### PR TITLE
Update Maistra to 0.10 and disable sidecar injection

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -7,7 +7,7 @@ set -x
 
 readonly BUILD_VERSION=v0.4.0
 readonly BUILD_RELEASE=https://github.com/knative/build/releases/download/${BUILD_VERSION}/build.yaml
-readonly MAISTRA_VERSION="0.6"
+readonly MAISTRA_VERSION="0.10"
 readonly SERVING_VERSION=v0.5.1
 readonly SERVING_RELEASE=https://github.com/knative/serving/releases/download/${SERVING_VERSION}/serving.yaml
 # We use nightly, to match the fact we do build here the latest from EVENTING
@@ -26,71 +26,70 @@ readonly TARGET_IMAGE_PREFIX="$INTERNAL_REGISTRY/$EVENTING_NAMESPACE/knative-eve
 
 env
 
-# Loops until duration (car) is exceeded or command (cdr) returns non-zero
-function timeout_non_zero() {
-  SECONDS=0; TIMEOUT=$1; shift
-  while eval $*; do
-    sleep 5
-    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && return 1
-  done
-  return 0
-}
-
-function patch_istio_for_knative(){
-  local sidecar_config=$(oc get configmap -n istio-system istio-sidecar-injector -o yaml)
-  if [[ -z "${sidecar_config}" ]]; then
-    return 1
-  fi
-  echo "${sidecar_config}" | grep lifecycle
-  if [[ $? -eq 1 ]]; then
-    echo "Patching Istio's preStop hook for graceful shutdown"
-    echo "${sidecar_config}" | sed 's/\(name: istio-proxy\)/\1\\n    lifecycle:\\n      preStop:\\n        exec:\\n          command: [\\"sh\\", \\"-c\\", \\"sleep 20; while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l | xargs) -ne 0 ]; do sleep 1; done\\"]/' | oc replace -f -
-    oc delete pod -n istio-system -l istio=sidecar-injector
-    wait_until_pods_running istio-system || return 1
-  fi
-  return 0
-}
-
 function install_istio(){
   header "Installing Istio"
 
   # Install the Maistra Operator
-  oc create namespace istio-operator
-  oc process -f https://raw.githubusercontent.com/Maistra/openshift-ansible/maistra-${MAISTRA_VERSION}/istio/istio_community_operator_template.yaml | oc create -f -
+  oc new-project istio-operator
+  oc new-project istio-system
+  oc apply -n istio-operator -f https://raw.githubusercontent.com/Maistra/istio-operator/maistra-${MAISTRA_VERSION}/deploy/maistra-operator.yaml
 
   # Wait until the Operator pod is up and running
   wait_until_pods_running istio-operator || return 1
 
   # Deploy Istio
   cat <<EOF | oc apply -f -
-apiVersion: istio.openshift.com/v1alpha1
-kind: Installation
+apiVersion: istio.openshift.com/v1alpha3
+kind: ControlPlane
 metadata:
-  namespace: istio-operator
-  name: istio-installation
+  name: basic-install
 spec:
   istio:
-    authentication: false
-    community: true
+    global:
+      # use community images
+      hub: "maistra"
+      tag: ${MAISTRA_VERSION}.0
+      proxy:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+    sidecarInjectorWebhook:
+      enabled: false
+    gateways:
+      istio-egressgateway:
+        autoscaleEnabled: false
+      istio-ingressgateway:
+        autoscaleEnabled: false
+        ior_enabled: false
+    mixer:
+      policy:
+        autoscaleEnabled: false
+      telemetry:
+        autoscaleEnabled: false
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1G
+          limits:
+            cpu: 200m
+            memory: 2G
+    pilot:
+      autoscaleEnabled: false
+    kiali:
+      enabled: false
+    tracing:
+      enabled: false
 EOF
 
-  # Wait until at least the istio installer job is running
-  wait_until_pods_running istio-system || return 1
+  # Wait until at least the Istio ControlPlane is installed
+  timeout 900 '[[ $(oc get ControlPlane/basic-install --template="{{range .status.conditions}}{{printf \"%s=%s, reason=%s, message=%s\n\n\" .type .status .reason .message}}{{end}}" | grep -c Installed=True) -eq 0 ]]' || return 1
 
-  timeout_non_zero 900 'oc get pods -n istio-system && [[ $(oc get pods -n istio-system | grep openshift-ansible-istio-installer | grep -c Completed) -eq 0 ]]' || return 1
-
-  # Scale down unused services deployed by the istio operator. The
-  # jaeger pods will fail anyway due to the elasticsearch pod failing
-  # due to "max virtual memory areas vm.max_map_count [65530] is too
-  # low, increase to at least [262144]" which could be mitigated on
-  # minishift with:
-  #  minishift ssh "echo 'echo vm.max_map_count = 262144 >/etc/sysctl.d/99-elasticsearch.conf' | sudo sh"
+  # Scale down unused services deployed by the istio operator
   oc scale -n istio-system --replicas=0 deployment/grafana
-  oc scale -n istio-system --replicas=0 deployment/jaeger-collector
-  oc scale -n istio-system --replicas=0 deployment/jaeger-query
-  oc scale -n istio-system --replicas=0 statefulset/elasticsearch
-
-  patch_istio_for_knative || return 1
   
   header "Istio Installed successfully"
 }
@@ -284,7 +283,7 @@ function run_e2e_tests(){
 
 function delete_istio_openshift(){
   echo ">> Bringing down Istio"
-  oc delete -n istio-operator installation istio-installation
+  oc delete ControlPlane/basic-install -n istio-system
 }
 
 function delete_serving_openshift() {


### PR DESCRIPTION
This works around the issues with Istio sidecars and OCP 4.1 by just disabling the mesh sidecars for now.