### PR TITLE
Remove the KnativeServing dep and rely on OwnerRef to show resources

### DIFF
--- a/openshift/olm/knative-eventing.catalogsource.yaml
+++ b/openshift/olm/knative-eventing.catalogsource.yaml
@@ -306,36 +306,11 @@ data:
       spec:
         apiservicedefinitions: {}
         customresourcedefinitions:
-          required:
-          - description: Represents an installation of a particular version of Knative Serving
-            displayName: Knative Serving
-            kind: Install
-            name: installs.serving.knative.dev
-            version: v1alpha1
           owned:
           - description: Represents an installation of a particular version of Knative Eventing
             displayName: Knative Eventing
             kind: Install
             name: installs.eventing.knative.dev
-            resources:
-            - kind: Namespace
-              name: ""
-              version: v1
-            - kind: CustomResourceDefinition
-              name: ""
-              version: v1beta1
-            - kind: Service
-              name: ""
-              version: v1
-            - kind: Deployment
-              name: ""
-              version: v1
-            - kind: Pod
-              name: ""
-              version: v1
-            - kind: ConfigMap
-              name: ""
-              version: v1
             statusDescriptors:
             - description: The version of Knative Eventing installed
               displayName: Version


### PR DESCRIPTION
See https://github.com/openshift-knative/knative-eventing-operator/commit/a309f5ac20b9b3d51a4d96374ade2bb8594317c4 

porting this here, since the generated `CS` is stored here ...

@lberk 