### PR TITLE
Using 0.6.0 for next release

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -178,6 +178,9 @@ function create_test_resources() {
     oc adm policy add-scc-to-user anyuid -z eventing-broker-filter -n $i
     oc adm policy add-scc-to-user privileged -z eventing-broker-filter -n $i
     oc adm policy add-cluster-role-to-user cluster-admin -z eventing-broker-filter -n $i
+    oc adm policy add-scc-to-user anyuid -z eventing-broker-ingress -n $i
+    oc adm policy add-scc-to-user privileged -z eventing-broker-ingress -n $i
+    oc adm policy add-cluster-role-to-user cluster-admin -z eventing-broker-ingress -n $i
   done
 
 }


### PR DESCRIPTION
porting changes from to master: 
https://github.com/openshift/knative-eventing/pull/141

once merged: we use the 0.6.0 operator


tests failures on the master, are true e2e fails, unrelated to the changes 