### PR TITLE
Fix OpenShift Conformance test suite

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -283,9 +283,10 @@ function run_origin_e2e() {
   oc -n $EVENTING_NAMESPACE create configmap kubeconfig --from-file=kubeconfig=$KUBECONFIG
   oc -n $EVENTING_NAMESPACE new-app -f ./openshift/origin-e2e-job.yaml --param-file=$param_file
   
-  timeout 240 "oc get pods -n $EVENTING_NAMESPACE | grep e2e-origin-testsuite | grep -E 'Running'"
+  timeout_non_zero 240 '[[ $(oc get pods -n $EVENTING_NAMESPACE | grep e2e-origin-testsuite | grep -c Running) -eq 0 ]]'
+  
   e2e_origin_pod=$(oc get pods -n $EVENTING_NAMESPACE | grep e2e-origin-testsuite | grep -E 'Running' | awk '{print $1}')
-  timeout 3600 "oc -n $EVENTING_NAMESPACE exec $e2e_origin_pod -c e2e-test-origin ls /tmp/artifacts/e2e-origin/test_logs.tar"
+  timeout_non_zero 3600 "! oc -n $EVENTING_NAMESPACE exec $e2e_origin_pod -c e2e-test-origin ls /tmp/artifacts/e2e-origin/test_logs.tar"
   oc cp ${EVENTING_NAMESPACE}/${e2e_origin_pod}:/tmp/artifacts/e2e-origin/test_logs.tar .
   tar xvf test_logs.tar -C /tmp/artifacts
   mkdir -p /tmp/artifacts/junit


### PR DESCRIPTION
Fixing the waiting loops because the old "timeout" function disappeared. This will fix the nightly job.

Should I also send this against master?