### PR TITLE
adding missing test images

### DIFF
--- a/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD heartbeats /usr/bin/heartbeats
+ENTRYPOINT ["/usr/bin/heartbeats"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD helloworld /usr/bin/helloworld
+ENTRYPOINT ["/usr/bin/helloworld"]


### PR DESCRIPTION
Since `release-next` is created _nightly_ and "openshift specific" files are added from master, I am adding dockerfiles for two more test images


However... they seem to be on the `release-next` branch already... 

@alanfx @lberk any thoughts ? 