### PR TITLE
release creation prep work

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -14,5 +14,6 @@ git fetch openshift master
 git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
 make RELEASE=$release generate-release
+make RELEASE=$release generate-kafka
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."


### PR DESCRIPTION
When creating the new release branch, we already generate our release yaml for CORE - but we should also do the same for kafka

@lberk 