### PR TITLE
Patching RBAC fix to our 'vendor,ed' image/release yaml

### DIFF
--- a/openshift/release/knative-eventing-v0.7.0.yaml
+++ b/openshift/release/knative-eventing-v0.7.0.yaml
@@ -224,6 +224,12 @@ rules:
       - "sequences/status"
     verbs: *everything
   - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "sequences/finalizers"
+    verbs:
+      - "update"
+  - apiGroups:
       - "sources.eventing.knative.dev"
     resources:
       - "cronjobsources"


### PR DESCRIPTION
@lberk based on the e2e test-failure of the nightly (a test for sequences was added to master), I see that RBAC was missing.

here is the snippet:

```
    tracker.go:128: Waiting for e2e-stepper1 to be deleted
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x173a57e]
 goroutine 88 [running]:
testing.tRunner.func1(0xc0002d0a00)
	/usr/local/go/src/testing/testing.go:830 +0x69d
panic(0x18ad100, 0x28f7e30)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/knative/eventing/test/base.GetAddressableURI(0x1c11000, 0xc0000105b0, 0xc000c3bb20, 0x0, 0x1, 0x90, 0x184a7e0)
	/go/src/github.com/knative/eventing/test/base/resource_inspectors.go:38 +0x12e
gi
```

the `panic: runtime error: invalid memory address or nil pointer dereference [recovered]` has been RBAC in the past.


I than did run a Sequence on Openshift, and was getting a "problem":

```
{
  "level": "error",
  "ts": "2019-07-02T08:48:43.619Z",
  "logger": "controller.sequence-controller",
  "caller": "sequence/sequence.go:96",
  "msg": "Error reconciling Sequence",
  "knative.dev/controller": "sequence-controller",
  "knative.dev/traceid": "194327ce-a8a6-4740-a49b-f9fed810c62f",
  "knative.dev/key": "default/sequence",
  "error": "inmemorychannels.messaging.knative.dev \"sequence-kn-sequence-0\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>",
  "stacktrace": "github.com/knative/eventing/pkg/reconciler/sequence.(*Reconciler).Reconcile\n\t/home/prow/go/src/github.com/knative/eventing/pkg/reconciler/sequence/sequence.go:96\ngithub.com/knative/eventing/vendor/github.com/knative/pkg/controller.(*Impl).processNextWorkItem\n\t/home/prow/go/src/github.com/knative/eventing/vendor/github.com/knative/pkg/controller/controller.go:330\ngithub.com/knative/eventing/vendor/github.com/knative/pkg/controller.(*Impl).Run.func1\n\t/home/prow/go/src/github.com/knative/eventing/vendor/github.com/knative/pkg/controller/controller.go:282"
}
```

and here is the upstream patch:
https://github.com/knative/eventing/pull/1495/commits/47b4d0f0f461c69c7ad2e2344ebcf8435f086556


Before applying the patch I did `oc edit clusterroles knative-eventing-controller` to test it, and yeah: worked, eventually 
