### PR TITLE
Adding NetworkPolicy workaround for webhook

### DIFF
--- a/openshift/release/knative-eventing-v0.7.1.yaml
+++ b/openshift/release/knative-eventing-v0.7.1.yaml
@@ -2071,3 +2071,17 @@ spec:
         - name: config-logging
           configMap:
             name: config-logging
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eventing-webhook
+  namespace: knative-eventing
+  labels:
+    app: eventing-webhook
+spec:
+  podSelector:
+    matchLabels:
+      app: eventing-webhook
+  ingress:
+  - {}


### PR DESCRIPTION
Here is the PR to patch the yaml, by adding the `NetworkPolicy` at the end of the "productized" yaml bag

/assign @maschmid 