### PR TITLE
adding fix for kafka-webhook

### DIFF
--- a/openshift/release/knative-eventing-kafka-v0.7.1.yaml
+++ b/openshift/release/knative-eventing-kafka-v0.7.1.yaml
@@ -677,3 +677,17 @@ spec:
         - name: config-logging
           configMap:
             name: config-logging
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kafka-webhook
+  namespace: knative-eventing
+  labels:
+    app: kafka-webhook
+spec:
+  podSelector:
+    matchLabels:
+      app: kafka-webhook
+  ingress:
+  - {}


### PR DESCRIPTION
Adding `NetworkPolicy` cfg for the `kafka-webhook`. 

This is the file that the kafka-operator points to 

/assign @maschmid 
/assign @lberk 