### PR TITLE
Using images we build during CI

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -184,7 +184,12 @@ function install_knative_eventing(){
 
   create_knative_namespace eventing
 
-  oc apply -n $OLM_NAMESPACE -f openshift/olm/knative-eventing.catalogsource.yaml
+  echo ">> Patching Knative Eventing CatalogSource to reference CI produced images"
+  CURRENT_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  RELEASE_YAML="https://raw.githubusercontent.com/openshift/knative-eventing/${CURRENT_GIT_BRANCH}/openshift/release/knative-eventing-ci.yaml"
+  sed "s|--filename=.*|--filename=${RELEASE_YAML}|"  openshift/olm/knative-eventing.catalogsource.yaml > knative-eventing.catalogsource-ci.yaml
+
+  oc apply -n $OLM_NAMESPACE -f knative-eventing.catalogsource-ci.yaml
   timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE
 

--- a/openshift/olm/knative-eventing.catalogsource.yaml
+++ b/openshift/olm/knative-eventing.catalogsource.yaml
@@ -872,6 +872,8 @@ data:
                       - name: OPERATOR_NAME
                         value: knative-eventing-operator
                       image: quay.io/openshift-knative/knative-eventing-operator:v0.9.0
+                      args:
+                        - --filename=https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.9.0/openshift/release/knative-eventing-v0.9.0.yaml
                       imagePullPolicy: Always
                       name: knative-eventing-operator
                       resources: {}


### PR DESCRIPTION
Updates in the PR:

* replace the operator content from vanilla upstream (no `filename argument`) with the those images that we build during the CI run.  For this I added the `filename` and re-enabled the OLM patch to replace the images in the content w/ those from the `...-ci.yaml` file

/assign @alanconway @lberk 

