### PR TITLE
Go with the new APIGroup for the Knative Serving install

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -64,7 +64,7 @@ function install_knative_serving(){
 
   # Install Knative Serving
   cat <<-EOF | oc apply -f -
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeServing
 metadata:
   name: knative-serving


### PR DESCRIPTION
upstream changed to that new group, which our serverless operator now uses for `KnativeServing` too

(while the old seems still supported)