### PR TITLE
SRVKE-308 failurePolicy: Ignore for sinkbindings webhooks

### DIFF
--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -80,7 +80,7 @@ webhooks:
           service:
             name: eventing-webhook
             namespace: knative-eventing
-        failurePolicy: Fail
+        failurePolicy: Ignore
         sideEffects: None
         name: sinkbindings.webhook.sources.knative.dev
 ---
@@ -97,7 +97,7 @@ webhooks:
       service:
         name: eventing-webhook
         namespace: knative-eventing
-    failurePolicy: Fail
+    failurePolicy: Ignore
     sideEffects: None
     name: legacysinkbindings.webhook.sources.knative.dev
 ---

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -255,7 +255,7 @@ function create_test_namespace(){
 function run_e2e_tests(){
   header "Running tests"
   report_go_test \
-    -v -tags=e2e -count=1 -timeout=35m -parallel=1 \
+    -v -tags=e2e -count=1 -timeout=70m -parallel=1 \
     ./test/e2e \
     --kubeconfig "$KUBECONFIG" \
     --dockerrepo "${INTERNAL_REGISTRY}/${EVENTING_NAMESPACE}" \

--- a/openshift/release/knative-eventing-v0.12.0.yaml
+++ b/openshift/release/knative-eventing-v0.12.0.yaml
@@ -2632,7 +2632,7 @@ webhooks:
           service:
             name: eventing-webhook
             namespace: knative-eventing
-        failurePolicy: Fail
+        failurePolicy: Ignore
         sideEffects: None
         name: sinkbindings.webhook.sources.knative.dev
 ---
@@ -2649,7 +2649,7 @@ webhooks:
       service:
         name: eventing-webhook
         namespace: knative-eventing
-    failurePolicy: Fail
+    failurePolicy: Ignore
     sideEffects: None
     name: legacysinkbindings.webhook.sources.knative.dev
 ---


### PR DESCRIPTION
The sinkbindings are too overreaching, blocking even infrastructure deployments when the webhook is down. 