### PR TITLE
EVenting image updates

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD ${bin} /usr/bin/${bin}
 ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/knative-images/apiserver_receive_adapter/Dockerfile
+++ b/openshift/ci-operator/knative-images/apiserver_receive_adapter/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD apiserver_receive_adapter /usr/bin/apiserver_receive_adapter
 ENTRYPOINT ["/usr/bin/apiserver_receive_adapter"]

--- a/openshift/ci-operator/knative-images/channel_broker/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_broker/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD channel_broker /usr/bin/channel_broker
+ENTRYPOINT ["/usr/bin/channel_broker"]

--- a/openshift/ci-operator/knative-images/channel_broker/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_broker/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD channel_broker /usr/bin/channel_broker
 ENTRYPOINT ["/usr/bin/channel_broker"]

--- a/openshift/ci-operator/knative-images/channel_controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_controller/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD channel_controller /usr/bin/channel_controller
 ENTRYPOINT ["/usr/bin/channel_controller"]

--- a/openshift/ci-operator/knative-images/channel_controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_controller/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD channel_controller /usr/bin/channel_controller
+ENTRYPOINT ["/usr/bin/channel_controller"]

--- a/openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD channel_dispatcher /usr/bin/channel_dispatcher
 ENTRYPOINT ["/usr/bin/channel_dispatcher"]

--- a/openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile
+++ b/openshift/ci-operator/knative-images/channel_dispatcher/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD channel_dispatcher /usr/bin/channel_dispatcher
+ENTRYPOINT ["/usr/bin/channel_dispatcher"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/ci-operator/knative-images/cronjob_receive_adapter/Dockerfile
+++ b/openshift/ci-operator/knative-images/cronjob_receive_adapter/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD cronjob_receive_adapter /usr/bin/cronjob_receive_adapter
 ENTRYPOINT ["/usr/bin/cronjob_receive_adapter"]

--- a/openshift/ci-operator/knative-images/filter/Dockerfile
+++ b/openshift/ci-operator/knative-images/filter/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD filter /usr/bin/filter
 ENTRYPOINT ["/usr/bin/filter"]

--- a/openshift/ci-operator/knative-images/ingress/Dockerfile
+++ b/openshift/ci-operator/knative-images/ingress/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD ingress /usr/bin/ingress
 ENTRYPOINT ["/usr/bin/ingress"]

--- a/openshift/ci-operator/knative-images/ping/Dockerfile
+++ b/openshift/ci-operator/knative-images/ping/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD ping /usr/bin/ping
+ENTRYPOINT ["/usr/bin/ping"]

--- a/openshift/ci-operator/knative-images/ping/Dockerfile
+++ b/openshift/ci-operator/knative-images/ping/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD ping /usr/bin/ping
 ENTRYPOINT ["/usr/bin/ping"]

--- a/openshift/ci-operator/knative-images/pong/Dockerfile
+++ b/openshift/ci-operator/knative-images/pong/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD pong /usr/bin/pong
 ENTRYPOINT ["/usr/bin/pong"]

--- a/openshift/ci-operator/knative-images/sendevent/Dockerfile
+++ b/openshift/ci-operator/knative-images/sendevent/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD sendevent /usr/bin/sendevent
 ENTRYPOINT ["/usr/bin/sendevent"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD webhook /usr/bin/webhook
 ENTRYPOINT ["/usr/bin/webhook"]

--- a/openshift/ci-operator/knative-test-images/eventdetails/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/eventdetails/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD eventdetails /usr/bin/eventdetails
 ENTRYPOINT ["/usr/bin/eventdetails"]

--- a/openshift/ci-operator/knative-test-images/eventdetails/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/eventdetails/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD eventdetails /usr/bin/eventdetails
+ENTRYPOINT ["/usr/bin/eventdetails"]

--- a/openshift/ci-operator/knative-test-images/filterevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/filterevents/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD filterevents /usr/bin/filterevents
+ENTRYPOINT ["/usr/bin/filterevents"]

--- a/openshift/ci-operator/knative-test-images/filterevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/filterevents/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD filterevents /usr/bin/filterevents
 ENTRYPOINT ["/usr/bin/filterevents"]

--- a/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD heartbeats /usr/bin/heartbeats
 ENTRYPOINT ["/usr/bin/heartbeats"]

--- a/openshift/ci-operator/knative-test-images/logevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/logevents/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD logevents /usr/bin/logevents
 ENTRYPOINT ["/usr/bin/logevents"]

--- a/openshift/ci-operator/knative-test-images/performance/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/performance/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD performance /usr/bin/performance
+ENTRYPOINT ["/usr/bin/performance"]

--- a/openshift/ci-operator/knative-test-images/performance/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/performance/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD performance /usr/bin/performance
 ENTRYPOINT ["/usr/bin/performance"]

--- a/openshift/ci-operator/knative-test-images/print/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/print/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD print /usr/bin/print
 ENTRYPOINT ["/usr/bin/print"]

--- a/openshift/ci-operator/knative-test-images/print/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/print/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD print /usr/bin/print
+ENTRYPOINT ["/usr/bin/print"]

--- a/openshift/ci-operator/knative-test-images/sendevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sendevents/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD sendevents /usr/bin/sendevents
+ENTRYPOINT ["/usr/bin/sendevents"]

--- a/openshift/ci-operator/knative-test-images/sendevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sendevents/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD sendevents /usr/bin/sendevents
 ENTRYPOINT ["/usr/bin/sendevents"]

--- a/openshift/ci-operator/knative-test-images/sequencestepper/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sequencestepper/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD sequencestepper /usr/bin/sequencestepper
 ENTRYPOINT ["/usr/bin/sequencestepper"]

--- a/openshift/ci-operator/knative-test-images/transformevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/transformevents/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+FROM openshift/origin-base
 
 ADD transformevents /usr/bin/transformevents
 ENTRYPOINT ["/usr/bin/transformevents"]


### PR DESCRIPTION
Part of removing the CI references, is here:

* update all images for current eventing on master/stash branch
* use better `FROM` on dockerfile to avoid CI registry hard coded 