### PR TITLE
tmp remove the resources for IMC dispatcher

### DIFF
--- a/openshift/011-remove-imc-dispatcher-resources.patch
+++ b/openshift/011-remove-imc-dispatcher-resources.patch
@@ -1,0 +1,17 @@
+diff --git a/config/channels/in-memory-channel/500-dispatcher.yaml b/config/channels/in-memory-channel/500-dispatcher.yaml
+index 0c0ffeb1..60c63fdc 100644
+--- a/config/channels/in-memory-channel/500-dispatcher.yaml
++++ b/config/channels/in-memory-channel/500-dispatcher.yaml
+@@ -47,12 +47,3 @@ spec:
+         ports:
+           - containerPort: 9090
+             name: metrics
+-        resources:
+-          # Set resource requests and limits based on the benchmarking results in
+-          # https://github.com/knative/eventing/issues/2311#issuecomment-565311345
+-          requests:
+-            cpu: 1000m
+-            memory: 256Mi
+-          limits:
+-            cpu: 2200m
+-            memory: 2048Mi

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -14,6 +14,7 @@ git checkout upstream/master -B release-next
 git fetch openshift master
 git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
 make generate-dockerfiles
+git apply openshift/011-remove-imc-dispatcher-resources.patch
 make RELEASE=ci generate-release
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m ":open_file_folder: Update openshift specific files."


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

I noticed this when setting up AWS/Openshift and had some issues w/ all IMCs . the dispatcher pod was pending.

Hence patching ours, just ours, for now.

More info on SRVKE-403

/assign @lberk 