### PR TITLE
Modify scripts to be reusable in serverless-operator repo

### DIFF
--- a/openshift/e2e-tests-local.sh
+++ b/openshift/e2e-tests-local.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC1090
+source "$(dirname "$0")/../test/e2e-common.sh"
 source "$(dirname "$0")/e2e-common.sh"
 
 set -x
+
+if [ -n "$TEMPLATE" ]; then
+  export TEST_IMAGE_TEMPLATE="$TEMPLATE"
+elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
+  export TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
+elif [ -n "$BRANCH" ]; then
+  export TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/${BRANCH}:knative-eventing-test-{{.Name}}"
+else
+  export TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-{{.Name}}"
+fi
 
 env
 

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC1090
+source "$(dirname "$0")/../test/e2e-common.sh"
 source "$(dirname "$0")/e2e-common.sh"
 
 set -x
+
+export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-test-{{.Name}}}"
 
 env
 


### PR DESCRIPTION
* remove redundant env variables
* move sourcing upstream e2e-commons out from our e2e-common
* hardcode TEST_IMAGE_TEMPLATE in e2e-tests.sh as this file only runs in
CI
* move selecting TEST_IMAGE_TEMPLATE into e2e-tests-local.sh as this is
where we want to specify custom templates
* use patch to modify KnativeEventing CR with a new defaultBrokerClass
* put back an option to run a single test with single tenant channel
based broker
* use ${variable:-} pattern where possible to prevent errors in
serverless-operator repo where we run with -e and undefined variables
fail the whole build

All these changes will be required in https://github.com/openshift-knative/serverless-operator/pull/346 where we want to re-use test execution of Eventing suites.