### PR TITLE
Modify scripts to be reusable in serverless-operator repo

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,29 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC1090
-source "$(dirname "$0")/../test/e2e-common.sh"
-source "$(dirname "$0")/release/resolve.sh"
-
-readonly SERVING_NAMESPACE=knative-serving
-readonly SERVICEMESH_NAMESPACE=knative-serving-ingress
-readonly EVENTING_NAMESPACE=knative-eventing
-readonly OLM_NAMESPACE=openshift-marketplace
-
-# Determine if we're running locally or in CI.
-if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-  # A golang template to point the tests to the right image coordinates.
-  # {{.Name}} is the name of the image, for example 'logevents'.
-  # IMAGE_FORMAT variable provided by ci-operator.
-  readonly TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-test-{{.Name}}}"
-elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
-  readonly TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
-elif [ -n "$BRANCH" ]; then
-  readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/${BRANCH}:knative-eventing-test-{{.Name}}"
-elif [ -n "$TEMPLATE" ]; then
-  readonly TEST_IMAGE_TEMPLATE="$TEMPLATE"
-else
-  readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-{{.Name}}"
-fi
+export EVENTING_NAMESPACE=knative-eventing
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"
@@ -169,16 +146,14 @@ function install_knative_eventing(){
 }
 
 function run_e2e_tests(){
-  header "Running tests with Multi Tenant Channel Based Broker"
-
-  local test_name=$1
+  local test_name="${1:-}"
   local failed=0
   local channels=messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.knative.dev/v1alpha1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel
-  local common_opts="-channels=$channels --kubeconfig $KUBECONFIG --imagetemplate $TEST_IMAGE_TEMPLATE $options"
+  local common_opts="-channels=$channels --kubeconfig $KUBECONFIG --imagetemplate $TEST_IMAGE_TEMPLATE"
 
   header "Running tests with Single Tenant Channel Based Broker"
   oc apply -f test/config/st-channel-broker.yaml || return 1
-  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+  wait_until_pods_running $EVENTING_NAMESPACE || return 2
 
   if [ -n "$test_name" ]; then # Running a single test.
     go_test_e2e -timeout=15m -parallel=1 ./test/e2e \
@@ -192,9 +167,9 @@ function run_e2e_tests(){
   fi
 
   header "Running tests with Multi Tenant Channel Based Broker"
-  oc apply -f config/core/configmaps/default-broker.yaml || return 1
+  oc apply -f config/core/configmaps/default-broker.yaml || return 3
   oc -n knative-eventing set env deployment/mt-broker-controller BROKER_INJECTION_DEFAULT=true || return 1
-  wait_until_pods_running $EVENTING_NAMESPACE || return 1
+  wait_until_pods_running $EVENTING_NAMESPACE || return 4
 
   if [ -n "$test_name" ]; then # Running a single test.
     go_test_e2e -timeout=15m -parallel=1 ./test/e2e \

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export EVENTING_NAMESPACE=knative-eventing
+export OLM_NAMESPACE=openshift-marketplace
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -152,7 +152,7 @@ function run_e2e_tests(){
   local common_opts="-channels=$channels --kubeconfig $KUBECONFIG --imagetemplate $TEST_IMAGE_TEMPLATE"
 
   header "Running tests with Single Tenant Channel Based Broker"
-  oc apply -f test/config/st-channel-broker.yaml || return 1
+  oc patch cm config-br-defaults -n $EVENTING_NAMESPACE -p '{"data":{"default-br-config":"clusterDefault:\n  brokerClass: ChannelBasedBroker\n  apiVersion: v1\n  kind: ConfigMap\n  name: config-br-default-channel\n  namespace: '$EVENTING_NAMESPACE'\n"}}' --type=merge ||  return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 2
 
   if [ -n "$test_name" ]; then # Running a single test.
@@ -167,7 +167,7 @@ function run_e2e_tests(){
   fi
 
   header "Running tests with Multi Tenant Channel Based Broker"
-  oc apply -f config/core/configmaps/default-broker.yaml || return 3
+  oc patch cm config-br-defaults -n $EVENTING_NAMESPACE -p '{"data":{"default-br-config":"clusterDefault:\n  brokerClass: MTChannelBasedBroker\n  apiVersion: v1\n  kind: ConfigMap\n  name: config-br-default-channel\n  namespace: '$EVENTING_NAMESPACE'\n"}}' --type=merge ||  return 3
   oc -n knative-eventing set env deployment/mt-broker-controller BROKER_INJECTION_DEFAULT=true || return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 4
 

--- a/openshift/e2e-tests-local.sh
+++ b/openshift/e2e-tests-local.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC1090
+source "$(dirname "$0")/../test/e2e-common.sh"
 source "$(dirname "$0")/e2e-common.sh"
 
 set -x
+
+if [ -n "$TEMPLATE" ]; then
+  export TEST_IMAGE_TEMPLATE="$TEMPLATE"
+elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
+  export TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
+elif [ -n "$BRANCH" ]; then
+  export TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/${BRANCH}:knative-eventing-test-{{.Name}}"
+else
+  export TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-{{.Name}}"
+fi
 
 env
 

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC1090
+source "$(dirname "$0")/../test/e2e-common.sh"
 source "$(dirname "$0")/e2e-common.sh"
 
 set -x
+
+export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-test-{{.Name}}}"
 
 env
 


### PR DESCRIPTION
* remove redundant env variables
* move sourcing upstream e2e-commons out from our e2e-common
* hardcode TEST_IMAGE_TEMPLATE in e2e-tests.sh as this file only runs in
CI
* move selecting TEST_IMAGE_TEMPLATE into e2e-tests-local.sh as this is
where we want to specify custom templates
* use ${variable:-} pattern where possible to prevent errors in
serverless-operator repo where we run with -e and undefined variables
fail the whole build

Similar to https://github.com/openshift/knative-eventing/pull/670, just for 0.15.1 branch.