### PR TITLE
Update channel broker image urls/names

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -166,6 +166,7 @@ function install_knative_eventing(){
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtbroker-ingress}|g"                   ci
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtbroker-filter}|g"                     ci
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtchannel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtchannel-broker}|g"                   ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-sugar-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-sugar-controller}|g"                   ci
 
   oc apply -f ci
   rm ci

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -149,9 +149,9 @@ function install_knative_eventing(){
 
   create_knative_namespace eventing
 
-  cat release/knative-eventing-ci.yaml > ci
-  cat release/knative-eventing-channelbroker-ci.yaml >> ci
-  cat release/knative-eventing-mtbroker-ci.yaml >> ci
+  cat openshift/release/knative-eventing-ci.yaml > ci
+  cat openshift/release/knative-eventing-channelbroker-ci.yaml >> ci
+  cat openshift/release/knative-eventing-mtbroker-ci.yaml >> ci
 
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-controller}|g"                               ci
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-ping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-ping}|g"                                           ci

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -167,7 +167,7 @@ function install_knative_eventing(){
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                       ci
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtchannel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                     ci
 
-  oc apply -n $OLM_NAMESPACE -f ci
+  oc apply -f ci
   rm ci
   timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -163,9 +163,9 @@ function install_knative_eventing(){
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                       ci
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                       ci
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                         ci
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                     ci
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                       ci
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtchannel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                     ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtbroker-ingress}|g"                   ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtbroker-filter}|g"                     ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtchannel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtchannel-broker}|g"                   ci
 
   oc apply -f ci
   rm ci

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -194,6 +194,11 @@ function run_e2e_tests(){
   local channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel
   local common_opts="-channels=$channels --kubeconfig $KUBECONFIG --imagetemplate $TEST_IMAGE_TEMPLATE $options"
 
+  k get ns ${TEST_EVENTING_NAMESPACE} 2>/dev/null || TEST_EVENTING_NAMESPACE="knative-eventing"
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} > tmp.tracing.config.yaml
+  oc replace -f tmp.tracing.config.yaml
+  rm tmp.tracing.config.yaml
+
   oc -n knative-eventing set env deployment/mt-broker-controller BROKER_INJECTION_DEFAULT=true || return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 1
 

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -149,9 +149,9 @@ function install_knative_eventing(){
 
   create_knative_namespace eventing
 
-  curl -L "https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-ci.yaml"               > ci
-  curl -L "https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-channelbroker-ci.yaml" >> ci
-  curl -L "https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-mtbroker-ci.yaml"      >> ci
+  cat release/knative-eventing-ci.yaml > ci
+  cat release/knative-eventing-channelbroker-ci.yaml >> ci
+  cat release/knative-eventing-mtbroker-ci.yaml >> ci
 
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-controller}|g"                               ci
   sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-ping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-ping}|g"                                           ci

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -169,13 +169,13 @@ function install_knative_eventing(){
 
   oc apply -f ci
   rm ci
-  timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
-  wait_until_pods_running $OLM_NAMESPACE
+  #timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
+  #wait_until_pods_running $OLM_NAMESPACE
 
-  oc get pod -n $OLM_NAMESPACE -o yaml
+  #oc get pod -n $OLM_NAMESPACE -o yaml
 
   # Deploy Knative Operators Eventing
-  deploy_knative_operator eventing KnativeEventing
+  #deploy_knative_operator eventing KnativeEventing
 
   # Wait for 5 pods to appear first
   timeout_non_zero 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -149,8 +149,22 @@ function install_knative_eventing(){
 
   create_knative_namespace eventing
 
+  CATALOG_SOURCE="openshift/olm/knative-eventing.catalogsource.yaml"
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-controller}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-ping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-ping}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtping}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-apiserver-receive-adapter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-apiserver-receive-adapter}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-webhook|${IMAGE_FORMAT//\$\{component\}/knative-eventing-webhook}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-controller}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-dispatcher|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-dispatcher}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                   ${CATALOG_SOURCE}
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtchannel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                   ${CATALOG_SOURCE}
   # oc apply -n $OLM_NAMESPACE -f knative-eventing.catalogsource-ci.yaml
-  oc apply -n $OLM_NAMESPACE -f openshift/olm/knative-eventing.catalogsource.yaml
+  oc apply -n $OLM_NAMESPACE -f ${CATALOG_SOURCE}
   timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE
 

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -149,22 +149,26 @@ function install_knative_eventing(){
 
   create_knative_namespace eventing
 
-  CATALOG_SOURCE="openshift/olm/knative-eventing.catalogsource.yaml"
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-controller}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-ping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-ping}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtping}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-apiserver-receive-adapter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-apiserver-receive-adapter}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-webhook|${IMAGE_FORMAT//\$\{component\}/knative-eventing-webhook}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-controller}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-dispatcher|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-dispatcher}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                   ${CATALOG_SOURCE}
-  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtchannel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                   ${CATALOG_SOURCE}
-  # oc apply -n $OLM_NAMESPACE -f knative-eventing.catalogsource-ci.yaml
-  oc apply -n $OLM_NAMESPACE -f ${CATALOG_SOURCE}
+  curl -L "https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-ci.yaml"               > ci
+  curl -L "https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-channelbroker-ci.yaml" >> ci
+  curl -L "https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-mtbroker-ci.yaml"      >> ci
+
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-controller}|g"                               ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-ping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-ping}|g"                                           ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtping|${IMAGE_FORMAT//\$\{component\}/knative-eventing-mtping}|g"                                       ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-apiserver-receive-adapter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-apiserver-receive-adapter}|g" ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-webhook|${IMAGE_FORMAT//\$\{component\}/knative-eventing-webhook}|g"                                     ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-controller|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-controller}|g"               ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-dispatcher|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-dispatcher}|g"               ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-channel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                       ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                       ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-broker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                         ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-ingress|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-ingress}|g"                     ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtbroker-filter|${IMAGE_FORMAT//\$\{component\}/knative-eventing-broker-filter}|g"                       ci
+  sed -i -e "s|registry.svc.ci.openshift.org/openshift/knative-.*:knative-eventing-mtchannel-broker|${IMAGE_FORMAT//\$\{component\}/knative-eventing-channel-broker}|g"                     ci
+
+  oc apply -n $OLM_NAMESPACE -f ci
+  rm ci
   timeout_non_zero 900 '[[ $(oc get pods -n $OLM_NAMESPACE | grep -c knative-eventing) -eq 0 ]]' || return 1
   wait_until_pods_running $OLM_NAMESPACE
 

--- a/openshift/olm/knative-eventing.catalogsource.yaml
+++ b/openshift/olm/knative-eventing.catalogsource.yaml
@@ -693,6 +693,38 @@ data:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: knative-eventing-operator
+                      - name: IMAGE_controller
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-controller
+                      - name: IMAGE_PING_IMAGE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ping
+                      - name: IMAGE_MT_PING_IMAGE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtping
+                      - name: IMAGE_APISERVER_RA_IMAGE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-apiserver-receive-adapter
+                      - name: IMAGE_webhook
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-webhook
+                      - name: IMAGE_imc-controller
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-controller
+                      - name: IMAGE_DISPATHCER_IMAGE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher
+                      - name: IMAGE_imc-dispatcher
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-dispatcher
+                      - name: IMAGE_broker-controller
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-broker
+                      - name: IMAGE_BROKER_INGRESS_IMAGE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress
+                      - name: IMAGE_BROKER_FILTER_IMAGE
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter
+                      - name: IMAGE_broker-filter
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter
+                      - name: IMAGE_mt-broker-filter
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-filter
+                      - name: IMAGE_broker-ingress
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress
+                      - name: IMAGE_mt-broker-ingress
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtbroker-ingress
+                      - name: IMAGE_mt_broker-controller
+                        value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-mtchannel-broker
                       image: quay.io/openshift-knative/knative-eventing-operator:v0.13.0
                       args:
                         - --filename=https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-ci.yaml,https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-channelbroker-ci.yaml,https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-mtbroker-ci.yaml

--- a/openshift/olm/knative-eventing.catalogsource.yaml
+++ b/openshift/olm/knative-eventing.catalogsource.yaml
@@ -695,7 +695,7 @@ data:
                         value: knative-eventing-operator
                       image: quay.io/openshift-knative/knative-eventing-operator:v0.13.0
                       args:
-                        - --filename=https://raw.githubusercontent.com/openshift/knative-eventing/release-next/openshift/release/knative-eventing-ci.yaml,https://raw.githubusercontent.com/openshift/knative-eventing/release-next/openshift/release/knative-eventing-channelbroker-ci.yaml,https://raw.githubusercontent.com/openshift/knative-eventing/release-next/openshift/release/knative-eventing-mtbroker-ci.yaml
+                        - --filename=https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-ci.yaml,https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-channelbroker-ci.yaml,https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.16.0/openshift/release/knative-eventing-mtbroker-ci.yaml
                       imagePullPolicy: Always
                       name: knative-eventing-operator
                       resources: {}

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -10,7 +10,7 @@ if [ "$release" == "ci" ]; then
     image_prefix="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-eventing-"
     tag=""
 else
-    image_prefix="registry.svc.ci.openshift.org/openshift/knative-${release}:knative-eventing-"
+    image_prefix="registry.svc.ci.openshift.org/openshift/knative-v${release}:knative-eventing-"
     tag=""
 fi
 

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -17,6 +17,11 @@ fi
 # the core parts
 resolve_resources config/ $output_file $image_prefix $tag
 
+# Sugar Controller
+resolve_resources config/sugar/ crd-sugar-resolved.yaml $image_prefix $tag
+cat crd-sugar-resolved.yaml >> $output_file
+rm crd-sugar-resolved.yaml
+
 # InMemoryChannel CRD
 resolve_resources config/channels/in-memory-channel/ crd-channel-resolved.yaml $image_prefix $tag
 cat crd-channel-resolved.yaml >> $output_file

--- a/openshift/release/knative-eventing-channelbroker-ci.yaml
+++ b/openshift/release/knative-eventing-channelbroker-ci.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
-        image: gcr.io/knative-releases/registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-broker@sha256:7d3ae9a7139a846490869e58d9f4ddbe31b8a60df306c3636962609fbcca523d
+        image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-channel-broker
         resources:
           requests:
             cpu: 100m
@@ -39,11 +39,11 @@ spec:
           - name: METRICS_DOMAIN
             value: knative.dev/eventing
           - name: BROKER_INGRESS_IMAGE
-            value: gcr.io/knative-releases/registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-ingress@sha256:a7a9dba94024ba961604f08be1bc49eddb40941dee4f291ed609149d899e7afa
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-ingress
           - name: BROKER_INGRESS_SERVICE_ACCOUNT
             value: eventing-broker-ingress
           - name: BROKER_FILTER_IMAGE
-            value: gcr.io/knative-releases/registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-filter@sha256:fa50a25fd2db5ab09cc604d2b3d4ad36da3687882352c68ca11cb273e65111f7
+            value: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-broker-filter
           - name: BROKER_FILTER_SERVICE_ACCOUNT
             value: eventing-broker-filter
           - name: BROKER_IMAGE_PULL_SECRET_NAME

--- a/openshift/release/knative-eventing-ci.yaml
+++ b/openshift/release/knative-eventing-ci.yaml
@@ -2039,6 +2039,45 @@ data:
     debug: "false"
     sample-rate: "0.1"
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sugar-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      eventing.knative.dev/role: sugar-controller
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: eventing-controller
+      containers:
+      - name: controller
+        image: registry.svc.ci.openshift.org/openshift/knative-v0.16.0:knative-eventing-sugar-controller
+        env:
+          - name: CONFIG_LOGGING_NAME
+            value: config-logging
+          - name: CONFIG_OBSERVABILITY_NAME
+            value: config-observability
+          - name: METRICS_DOMAIN
+            value: knative.dev/sugar-controller
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -31,6 +31,7 @@ function resolve_resources(){
         -e "s+knative.dev/eventing/cmd/ping+${image_prefix}ping${image_tag}+" \
         -e "s+knative.dev/eventing/cmd/mtping+${image_prefix}mtping${image_tag}+" \
         -e "s+knative.dev/eventing/cmd/apiserver_receive_adapter+${image_prefix}apiserver-receive-adapter${image_tag}+" \
+        -e "s+knative.dev/eventing/cmd/sugar_controller+${image_prefix}sugar-controller${image_tag}+" \
         -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
         -e '/^[ \t]*#/d' \
         -e '/^[ \t]*$/d' \


### PR DESCRIPTION
script produced urls that had a prefix of `gcr.io/knative-releases` drop and fix image names