### PR TITLE
SRVKE-472: reenable flows e2e tests 

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -6,6 +6,9 @@ source "$(dirname "$0")/release/resolve.sh"
 set -x
 
 readonly EVENTING_NAMESPACE=knative-eventing
+# A golang template to point the tests to the right image coordinates.
+# {{.Name}} is the name of the image, for example 'autoscale'.
+readonly TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:knative-eventing-test-{{.Name}}"
 
 env
 
@@ -62,9 +65,9 @@ function run_e2e_tests(){
   header "Running tests"
   report_go_test \
     -v -tags=e2e -count=1 -timeout=70m -parallel=12 \
-    ./test/e2e \
+    ./test/e2e -channels=messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.knative.dev/v1alpha1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel \
     --kubeconfig "$KUBECONFIG" \
-    --dockerrepo "quay.io/openshift-knative" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     ${options} || failed=1
 }
 

--- a/test/e2e/parallel_test.go
+++ b/test/e2e/parallel_test.go
@@ -39,8 +39,6 @@ type branchConfig struct {
 }
 
 func TestFlowsParallel(t *testing.T) {
-	// Skip test. Has been added manually not via patch, so please analyse this test and remove that line when fixed.
-	// t.Skip("SRVKE-472: Skipping broken test for now. Considered to be not harmful for OpenShift Serverless 1.7.2, but needs to be fixed.")
 	const (
 		senderPodName = "e2e-parallel"
 	)

--- a/test/e2e/parallel_test.go
+++ b/test/e2e/parallel_test.go
@@ -40,7 +40,7 @@ type branchConfig struct {
 
 func TestFlowsParallel(t *testing.T) {
 	// Skip test. Has been added manually not via patch, so please analyse this test and remove that line when fixed.
-	t.Skip("SRVKE-472: Skipping broken test for now. Considered to be not harmful for OpenShift Serverless 1.7.2, but needs to be fixed.")
+	// t.Skip("SRVKE-472: Skipping broken test for now. Considered to be not harmful for OpenShift Serverless 1.7.2, but needs to be fixed.")
 	const (
 		senderPodName = "e2e-parallel"
 	)

--- a/test/e2e/sequence_test.go
+++ b/test/e2e/sequence_test.go
@@ -36,8 +36,6 @@ import (
 )
 
 func TestFlowsSequence(t *testing.T) {
-	// Skip test. Has been added manually not via patch, so please analyse this test and remove that line when fixed.
-	t.Skip("SRVKE-472: Skipping broken test for now. Considered to be not harmful for OpenShift Serverless 1.7.2, but needs to be fixed.")
 	const (
 		sequenceName  = "e2e-sequence"
 		senderPodName = "e2e-sequence-sender-pod"


### PR DESCRIPTION
see: https://issues.redhat.com/browse/SRVKE-472

relates to: https://github.com/openshift/knative-eventing/pull/692

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>