### PR TITLE
Adding conformance test for OCP run

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -178,7 +178,7 @@ function run_e2e_tests(){
   oc -n knative-eventing set env deployment/mt-broker-controller BROKER_INJECTION_DEFAULT=true || return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 2
 
-  go_test_e2e -timeout=90m -parallel=12 ./test/e2e \
+  go_test_e2e -timeout=90m -parallel=12 ./test/e2e ./test/conformance \
     "$run_command" \
     -brokerclass=MTChannelBasedBroker \
     $common_opts || failed=$?

--- a/openshift/patches/012-skip-tracing-conformance.patch
+++ b/openshift/patches/012-skip-tracing-conformance.patch
@@ -1,0 +1,22 @@
+diff --git a/test/conformance/broker_tracing_test.go b/test/conformance/broker_tracing_test.go
+index 6e8a124dd..2ef3a64ec 100644
+--- a/test/conformance/broker_tracing_test.go
++++ b/test/conformance/broker_tracing_test.go
+@@ -26,5 +26,6 @@ import (
+ )
+ 
+ func TestBrokerTracing(t *testing.T) {
++        t.Skip("We for now ignore tracing tests")
+ 	helpers.BrokerTracingTestHelperWithChannelTestRunner(t, brokerClass, channelTestRunner, testlib.SetupClientOptionNoop)
+ }
+diff --git a/test/conformance/channel_tracing_test.go b/test/conformance/channel_tracing_test.go
+index 5690f42ff..857f36050 100644
+--- a/test/conformance/channel_tracing_test.go
++++ b/test/conformance/channel_tracing_test.go
+@@ -26,5 +26,6 @@ import (
+ )
+ 
+ func TestChannelTracingWithReply(t *testing.T) {
++        t.Skip("We for now ignore tracing tests")
+ 	helpers.ChannelTracingTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+ }

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -19,7 +19,7 @@ git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m ":open_file_folder: Update openshift specific files."
 
 # Apply patches .
-# git apply openshift/patches/*
+git apply openshift/patches/*
 make RELEASE=ci generate-release
 git commit -am ":fire: Apply carried patches."
 


### PR DESCRIPTION
However, we TEMPORARY skip the two tracing related tests

was tested with: #764



Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>