### PR TITLE
Adding CRD install label first, to avoid race

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -51,6 +51,7 @@ function install_strimzi(){
   strimzi_version=`curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null`
   header_text "Strimzi install"
   kubectl create namespace kafka
+  kubectl -n kafka apply --selector strimzi.io/crd-install=true -f "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml"
   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml" \
   | sed 's/namespace: .*/namespace: kafka/' \
   | kubectl -n kafka apply -f -


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Sometimes we face races during strimzi install. See the error log:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_knative-eventing/772/pull-ci-openshift-knative-eventing-release-next-45-e2e-aws-ocp-45/1295589721136697344

```
...
openshift/e2e-common.sh: line 58: header_text: command not found
+ kubectl -n kafka apply -f https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.19.0/examples/kafka/kafka-persistent-single.yaml
error: unable to recognize "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.19.0/examples/kafka/kafka-persistent-single.yaml": no matches for kind "Kafka" in version "kafka.strimzi.io/v1beta1"
+ header_text 'Waiting for Strimzi to become ready'
...
```


and on Strimzi, a selector for crd install was added, see:
https://github.com/strimzi/strimzi-kafka-operator/issues/2504

This PR basically makes usage of that