### PR TITLE
Fixing the disabled image promotion for all branches

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -19,7 +19,7 @@ test -d "$CONFIGDIR" || fail "'$CONFIGDIR' is not a directory"
 # Generate CI config files
 CONFIG=$CONFIGDIR/openshift-knative-eventing-release-$VERSION
 CURDIR=$(dirname $0)
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.5 true > ${CONFIG}__45.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.5 > ${CONFIG}__45.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.6 true > ${CONFIG}__46.yaml
 
 # Switch to openshift/release to generate PROW files


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


we need at least one "promotion" branch

/assign @lberk 