### PR TITLE
[0.16] Updating linux container to have httpd-tools

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -5,7 +5,7 @@ FROM openshift/origin-release:golang-1.14
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
-RUN yum install -y kubectl ansible
+RUN yum install -y kubectl ansible httpd-tools
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Like on `release-next` and the `release-014....` branches, we need the `httpd-tools` to install/build the Serverless Operator 1.8 (and later)