### PR TITLE
SRVKE-509 sleep after send to let traces publish

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -20,6 +20,8 @@ failed=0
 
 (( !failed )) && install_knative_eventing || failed=1
 
+(( !failed )) && install_zipkin || failed=1
+
 (( !failed )) && run_e2e_tests || failed=1
 
 (( failed )) && dump_cluster_state

--- a/test/test_images/sendevents/main.go
+++ b/test/test_images/sendevents/main.go
@@ -178,6 +178,13 @@ func main() {
 		<-ticker.C
 		// Only send a limited number of messages.
 		if maxMsg != 0 && maxMsg == sequence {
+
+			if addTracing {
+				log.Printf("will sleep for 5s to let the traces be published")
+				time.Sleep(5 * time.Second)
+				log.Printf("awake, exiting")
+			}
+
 			return
 		}
 	}


### PR DESCRIPTION
Workaround to fix tracing conformance tests flakiness on OpenShift.

Should not be needed upstream, as the request-sender has changed in 0.16 to only propagate tracing, not send its own spans to zipkin.