### PR TITLE
Do not source test/e2e-common.sh - release-v0.17.2

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -3,6 +3,8 @@
 export EVENTING_NAMESPACE=knative-eventing
 export TEST_EVENTING_NAMESPACE=$EVENTING_NAMESPACE
 export OLM_NAMESPACE=openshift-marketplace
+export KNATIVE_DEFAULT_NAMESPACE=$EVENTING_NAMESPACE
+export CONFIG_TRACING_CONFIG="test/config/config-tracing.yaml"
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"

--- a/openshift/e2e-tests-local.sh
+++ b/openshift/e2e-tests-local.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC1090
-source "$(dirname "$0")/../test/e2e-common.sh"
+source "$(dirname "$0")/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh"
 source "$(dirname "$0")/e2e-common.sh"
 
-set -x
+set -Eeuox pipefail
 
-if [ -n "$TEMPLATE" ]; then
+if [ -n "${TEMPLATE:-}" ]; then
   export TEST_IMAGE_TEMPLATE="$TEMPLATE"
-elif [ -n "$DOCKER_REPO_OVERRIDE" ]; then
+elif [ -n "${DOCKER_REPO_OVERRIDE:-}" ]; then
   export TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
-elif [ -n "$BRANCH" ]; then
+elif [ -n "${BRANCH:-}" ]; then
   export TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/${BRANCH}:knative-eventing-test-{{.Name}}"
 else
   export TEST_IMAGE_TEMPLATE="registry.svc.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-{{.Name}}"
@@ -20,7 +20,7 @@ env
 
 failed=0
 
-(( !failed )) && run_e2e_tests "$TEST" || failed=1
+(( !failed )) && run_e2e_tests "${TEST:-}" || failed=1
 
 (( failed )) && dump_cluster_state
 

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC1090
-source "$(dirname "$0")/../test/e2e-common.sh"
+source "$(dirname "$0")/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh"
 source "$(dirname "$0")/e2e-common.sh"
 
-set -x
+set -Eeuox pipefail
 
 export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-test-{{.Name}}}"
 


### PR DESCRIPTION
* the openshift/e2e-commons.sh script is reused in other repos (e.g.
sererless-operator) which doesn't have the test/e2e-common.sh from
Eventing available
* we source only helper functions from test-infra that are commons to
all our forks and also to serverless-operator
* add explicit fail via set -e that will show which variables are
undefined
* the result of this is that we might need to define variables in
openshift/e2e-common.sh more frequently because we're not reusing
anything from test/e2e-common.sh