### PR TITLE
WIP: Adding the v1 test to the list of skipped tests

### DIFF
--- a/test/e2e/source_sinkbinding_v1_test.go
+++ b/test/e2e/source_sinkbinding_v1_test.go
@@ -126,6 +126,7 @@ func TestSinkBindingV1Deployment(t *testing.T) {
 }
 
 func TestSinkBindingV1CronJob(t *testing.T) {
+	t.Skip("SRVKE-500: Skipping since we set bindings to inclusion")
 	const (
 		sinkBindingName = "e2e-sink-binding"
 		deploymentName  = "e2e-sink-binding-cronjob"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


we have already a few sinkbinding tests skipped, since we change the default value from upstream for us/openshift.

This adds the newly added v1 test to the list

NOTE: Do not merge - this is only a test. 