### PR TITLE
Adding one more sinkbinding test to the list of skipped tests

### DIFF
--- a/openshift/patches/015-sinkbinding_v1_tests_skip.patch
+++ b/openshift/patches/015-sinkbinding_v1_tests_skip.patch
@@ -1,0 +1,12 @@
+diff --git a/test/e2e/source_sinkbinding_v1_test.go b/test/e2e/source_sinkbinding_v1_test.go
+index 456069539..8328b6b83 100644
+--- a/test/e2e/source_sinkbinding_v1_test.go
++++ b/test/e2e/source_sinkbinding_v1_test.go
+@@ -126,6 +126,7 @@ func TestSinkBindingV1Deployment(t *testing.T) {
+ }
+ 
+ func TestSinkBindingV1CronJob(t *testing.T) {
++	t.Skip("SRVKE-500: Skipping since we set bindings to inclusion")
+ 	const (
+ 		sinkBindingName = "e2e-sink-binding"
+ 		deploymentName  = "e2e-sink-binding-cronjob"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

This bascially will ensure we always patch the newly added (upstream) v1 test for sinkbinding.

See https://github.com/openshift/knative-eventing/pull/886  as well

/hold

/assign @lberk 