### PR TITLE
Removing 4.5 channel, we are defaulting to 4.6

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -19,8 +19,7 @@ test -d "$CONFIGDIR" || fail "'$CONFIGDIR' is not a directory"
 # Generate CI config files
 CONFIG=$CONFIGDIR/openshift-knative-eventing-release-$VERSION
 CURDIR=$(dirname $0)
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.5 > ${CONFIG}__45.yaml
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.6 true > ${CONFIG}__46.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.6 > ${CONFIG}__46.yaml
 
 # Switch to openshift/release to generate PROW files
 cd $OPENSHIFT


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

With 1.11 (which is 0.17) SERVERLESS we start to default to 4.6

Therefore removing the need fro 4.5 on our future releases

/assign @lberk 