### PR TITLE
[release-v0.17.2] Backport: PR 4442

### DIFF
--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -34,7 +34,7 @@ const (
 	readyMessage = "prober ready"
 )
 
-func TestContinuousEventsPropagationWithProber(t *testing.T) {
+func TestEventsPropagationWithProber(t *testing.T) {
 	// We run the prober as a golang test because it fits in nicely with
 	// the rest of our integration tests, and AssertProberDefault needs
 	// a *testing.T. Unfortunately, "go test" intercepts signals, so we


### PR DESCRIPTION
Backporting PR knative#4442 to [release-v0.17.2 branch](https://github.com/openshift/knative-eventing/tree/release-v0.17.2).

This is required by https://github.com/openshift-knative/serverless-operator/pull/530#issuecomment-717367653