### PR TITLE
[release-v0.17.2] Hotfix: Deploying receiver as ksvc if serving is available

### DIFF
--- a/test/upgrade/prober/forwarder.go
+++ b/test/upgrade/prober/forwarder.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/wavesoftware/go-ensure"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	testlib "knative.dev/eventing/test/lib"
@@ -27,24 +28,22 @@ import (
 	pkgTest "knative.dev/pkg/test"
 )
 
-var (
-	forwarderName = "wathola-forwarder"
-)
+var forwarderName = "wathola-forwarder"
 
 func (p *prober) deployForwarder() {
-	p.log.Infof("Deploy forwarder knative service: %v", forwarderName)
+	p.log.Info("Deploy forwarder knative service: ", forwarderName)
 	serving := p.client.Dynamic.Resource(resources.KServicesGVR).Namespace(p.client.Namespace)
 	service := p.forwarderKService(forwarderName, p.client.Namespace)
 	_, err := serving.Create(service, metav1.CreateOptions{})
 	ensure.NoError(err)
 
 	sc := p.servingClient()
-	testlib.WaitFor(fmt.Sprintf("forwarder ksvc be ready: %v", forwarderName), func() error {
+	testlib.WaitFor(fmt.Sprint("forwarder knative service be ready: ", forwarderName), func() error {
 		return duck.WaitForKServiceReady(sc, forwarderName, p.client.Namespace)
 	})
 
 	if p.config.Serving.ScaleToZero {
-		testlib.WaitFor(fmt.Sprintf("forwarder scales to zero: %v", forwarderName), func() error {
+		testlib.WaitFor(fmt.Sprint("forwarder scales to zero: ", forwarderName), func() error {
 			return duck.WaitForKServiceScales(sc, forwarderName, p.client.Namespace, func(scale int) bool {
 				return scale == 0
 			})
@@ -53,49 +52,47 @@ func (p *prober) deployForwarder() {
 }
 
 func (p *prober) removeForwarder() {
-	p.log.Infof("Remove forwarder knative service: %v", forwarderName)
+	p.log.Info("Remove forwarder knative service: ", forwarderName)
 	serving := p.client.Dynamic.Resource(resources.KServicesGVR).Namespace(p.client.Namespace)
 	err := serving.Delete(forwarderName, &metav1.DeleteOptions{})
 	ensure.NoError(err)
 }
 
 func (p *prober) forwarderKService(name, namespace string) *unstructured.Unstructured {
-	obj := map[string]interface{}{
-		"apiVersion": resources.KServiceType.APIVersion,
-		"kind":       resources.KServiceType.Kind,
-		"metadata": map[string]interface{}{
-			"name":      name,
-			"namespace": namespace,
-			"labels": map[string]string{
-				"serving.knative.dev/visibility": "cluster-local",
-			},
+	return kService(metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels: map[string]string{
+			"serving.knative.dev/visibility": "cluster-local",
 		},
-		"spec": map[string]interface{}{
-			"template": map[string]interface{}{
-				"spec": map[string]interface{}{
-					"containers": []map[string]interface{}{{
-						"name":  "forwarder",
-						"image": pkgTest.ImagePath(forwarderName),
-						"volumeMounts": []map[string]interface{}{{
-							"name":      p.config.ConfigMapName,
-							"mountPath": p.config.ConfigMountPoint,
-							"readOnly":  true,
-						}},
-						"readinessProbe": map[string]interface{}{
-							"httpGet": map[string]interface{}{
-								"path": p.config.HealthEndpoint,
-							},
-						},
-					}},
-					"volumes": []map[string]interface{}{{
-						"name": p.config.ConfigMapName,
-						"configMap": map[string]interface{}{
-							"name": p.config.ConfigMapName,
-						},
-					}},
+	}, corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  "forwarder",
+			Image: pkgTest.ImagePath(forwarderName),
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      p.config.ConfigMapName,
+					MountPath: p.config.ConfigMountPoint,
+					ReadOnly:  true,
 				},
 			},
-		},
-	}
-	return &unstructured.Unstructured{Object: obj}
+			ReadinessProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: p.config.HealthEndpoint,
+					},
+				},
+			},
+		}},
+		Volumes: []corev1.Volume{{
+			Name: p.config.ConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: p.config.ConfigMapName,
+					},
+				},
+			},
+		}},
+	})
 }

--- a/test/upgrade/prober/kservice.go
+++ b/test/upgrade/prober/kservice.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"knative.dev/eventing/test/lib/resources"
+)
+
+func kService(meta metav1.ObjectMeta, spec corev1.PodSpec) *unstructured.Unstructured {
+	if len(spec.Containers) != 1 {
+		panic("kService func supports PodSpec with 1 container only")
+	}
+	container := spec.Containers[0]
+	if len(spec.Volumes) != 1 || len(container.VolumeMounts) != 1 {
+		panic("kService func supports PodSpec with 1 volume only")
+	}
+	volume := spec.Volumes[0]
+	volmount := container.VolumeMounts[0]
+	obj := map[string]interface{}{
+		"apiVersion": resources.KServiceType.APIVersion,
+		"kind":       resources.KServiceType.Kind,
+		"metadata": map[string]interface{}{
+			"name":      meta.Name,
+			"namespace": meta.Namespace,
+			"labels":    meta.Labels,
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": meta.Annotations,
+				},
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{{
+						"name":  container.Name,
+						"image": container.Image,
+						"volumeMounts": []map[string]interface{}{{
+							"name":      volmount.Name,
+							"mountPath": volmount.MountPath,
+							"readOnly":  true,
+						}},
+						"readinessProbe": map[string]interface{}{
+							"httpGet": map[string]interface{}{
+								"path": container.ReadinessProbe.HTTPGet.Path,
+							},
+						},
+					}},
+					"volumes": []map[string]interface{}{{
+						"name": volume.Name,
+						"configMap": map[string]interface{}{
+							"name": volume.ConfigMap.Name,
+						},
+					}},
+				},
+			},
+		},
+	}
+	return &unstructured.Unstructured{Object: obj}
+}

--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -123,6 +123,7 @@ func (p *prober) deploy() {
 func (p *prober) remove() {
 	if p.config.Serving.Use {
 		p.removeForwarder()
+		p.removeReceiverKService()
 	}
 	ensure.NoError(p.client.Tracker.Clean(true))
 }

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -21,21 +21,23 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/wavesoftware/go-ensure"
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	"knative.dev/eventing/test/lib/nodes"
 )
 
 func (p *prober) Verify() ([]error, int) {
-	nc := nodes.Client(p.client.Kube.Kube, p.log)
-	node, err := nc.RandomWorkerNode()
-	ensure.NoError(err)
-	address := nc.GuessNodeExternalAddress(node)
-	p.log.Debugf("Address resolved: %v, type: %v", address.Address, address.Type)
-	report := fetchReceiverReport(address, p.log)
+	var urlResolver func() *url.URL
+	if p.config.Serving.Use {
+		urlResolver = p.receiverKServiceAddress
+	} else {
+		urlResolver = p.receiverAddressByWorkerExternalAddressNodePort
+	}
+	u := urlResolver()
+	report := fetchReceiverReport(u, p.log)
 	p.log.Infof("Fetched receiver report. Events propagated: %v. "+
 		"State: %v", report.Events, report.State)
 	if report.State == "active" {
@@ -52,10 +54,22 @@ func (p *prober) Finish() {
 	p.removeSender()
 }
 
-func fetchReceiverReport(address *corev1.NodeAddress, log *zap.SugaredLogger) *Report {
-	u := fmt.Sprintf("http://%s:%d/report", address.Address, receiverNodePort)
+func (p *prober) receiverAddressByWorkerExternalAddressNodePort() *url.URL {
+	nc := nodes.Client(p.client.Kube.Kube, p.log)
+	node, err := nc.RandomWorkerNode()
+	ensure.NoError(err)
+	address := nc.GuessNodeExternalAddress(node)
+	p.log.Debugf("Address resolved: %v, type: %v", address.Address, address.Type)
+
+	u, err := url.Parse(fmt.Sprintf("http://%s:%d/report",
+		address.Address, receiverNodePort))
+	ensure.NoError(err)
+	return u
+}
+
+func fetchReceiverReport(u *url.URL, log *zap.SugaredLogger) *Report {
 	log.Infof("Fetching receiver report from: %v", u)
-	resp, err := http.Get(u)
+	resp, err := http.Get(u.String())
 	ensure.NoError(err)
 	if resp.StatusCode != 200 {
 		var b strings.Builder


### PR DESCRIPTION
This is a possible backport of upstream PR knative#4430. That depends on that upstream PR being merged. I don't give a huge confidence that happening.

If upstream PR will be merged, then nothing more isn't required for 0.18+. 

Otherwise, this PR must be also converted to a patch on master branch. Then it must be applied on each release-next, until a proper fix for knative#3175 is provided.

This is required for https://github.com/openshift-knative/serverless-operator/pull/530#issuecomment-717367653