### PR TITLE
[release-v0.17.2] Hotfix: Use deployment to avoid disparity in effective user

### DIFF
--- a/test/upgrade/prober/receiver.go
+++ b/test/upgrade/prober/receiver.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/wavesoftware/go-ensure"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -33,61 +34,22 @@ var (
 )
 
 func (p *prober) deployReceiver() {
-	p.deployReceiverPod()
+	p.deployReceiverDeployment()
 	p.deployReceiverService()
 }
 
-func (p *prober) deployReceiverPod() {
-	p.log.Infof("Deploy of receiver pod: %v", receiverName)
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      receiverName,
-			Namespace: p.config.Namespace,
-			Labels: map[string]string{
-				"app": receiverName,
-			},
-		},
-		Spec: corev1.PodSpec{
-			Volumes: []corev1.Volume{
-				{
-					Name: p.config.ConfigMapName,
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: p.config.ConfigMapName,
-							},
-						},
-					},
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:  "receiver",
-					Image: pkgTest.ImagePath(receiverName),
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      p.config.ConfigMapName,
-							ReadOnly:  true,
-							MountPath: p.config.ConfigMountPoint,
-						},
-					},
-					ReadinessProbe: &corev1.Probe{
-						Handler: corev1.Handler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path: p.config.HealthEndpoint,
-								Port: intstr.FromInt(watholaconfig.DefaultReceiverPort),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	_, err := p.client.Kube.CreatePod(pod)
+func (p *prober) deployReceiverDeployment() {
+	p.log.Info("Deploy of receiver deployment: ", receiverName)
+	deployment := p.createReceiverDeployment()
+	_, err := p.client.Kube.Kube.AppsV1().
+		Deployments(deployment.Namespace).
+		Create(deployment)
 	ensure.NoError(err)
 
-	testlib.WaitFor(fmt.Sprintf("receiver be ready: %v", receiverName), func() error {
-		return pkgTest.WaitForPodRunning(p.client.Kube, receiverName, p.client.Namespace)
+	testlib.WaitFor(fmt.Sprint("receiver deployment be ready: ", receiverName), func() error {
+		return pkgTest.WaitForDeploymentScale(
+			p.client.Kube, receiverName, p.client.Namespace, 1,
+		)
 	})
 }
 
@@ -128,5 +90,59 @@ func (p *prober) deployReceiverService() {
 		panic(fmt.Errorf("couldn't find a node port for service: %v", receiverName))
 	} else {
 		p.log.Debugf("Node port for service: %v is %v", receiverName, receiverNodePort)
+	}
+}
+
+func (p *prober) createReceiverDeployment() *appsv1.Deployment {
+	var replicas int32 = 1
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      receiverName,
+			Namespace: p.config.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": receiverName,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": receiverName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: p.config.ConfigMapName,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: p.config.ConfigMapName,
+								},
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name:  "receiver",
+						Image: pkgTest.ImagePath(receiverName),
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      p.config.ConfigMapName,
+							ReadOnly:  true,
+							MountPath: p.config.ConfigMountPoint,
+						}},
+						ReadinessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: p.config.HealthEndpoint,
+									Port: intstr.FromInt(watholaconfig.DefaultReceiverPort),
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
 	}
 }

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/wavesoftware/go-ensure"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testlib "knative.dev/eventing/test/lib"
@@ -28,53 +29,68 @@ import (
 var senderName = "wathola-sender"
 
 func (p *prober) deploySender() {
-	p.log.Infof("Deploy sender pod: %v", senderName)
-	pod := &corev1.Pod{
+	p.log.Info("Deploy sender deployment: ", senderName)
+	var replicas int32 = 1
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      senderName,
 			Namespace: p.config.Namespace,
 		},
-		Spec: corev1.PodSpec{
-			Volumes: []corev1.Volume{
-				{
-					Name: p.config.ConfigMapName,
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: p.config.ConfigMapName,
-							},
-						},
-					},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": senderName,
 				},
 			},
-			Containers: []corev1.Container{
-				{
-					Name:  "sender",
-					Image: pkgTest.ImagePath(senderName),
-					VolumeMounts: []corev1.VolumeMount{
-						{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": senderName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: p.config.ConfigMapName,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: p.config.ConfigMapName,
+								},
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name:  "sender",
+						Image: pkgTest.ImagePath(senderName),
+						VolumeMounts: []corev1.VolumeMount{{
 							Name:      p.config.ConfigMapName,
 							ReadOnly:  true,
 							MountPath: p.config.ConfigMountPoint,
-						},
-					},
+						}},
+					}},
 				},
 			},
 		},
 	}
-	_, err := p.client.Kube.Kube.CoreV1().Pods(p.client.Namespace).
-		Create(pod)
+
+	_, err := p.client.Kube.Kube.AppsV1().
+		Deployments(p.client.Namespace).
+		Create(deployment)
 	ensure.NoError(err)
 
-	testlib.WaitFor(fmt.Sprintf("sender pod be ready: %v", senderName), func() error {
-		return pkgTest.WaitForPodRunning(p.client.Kube, senderName, p.client.Namespace)
+	testlib.WaitFor(fmt.Sprint("sender deployment be ready: ", senderName), func() error {
+		return pkgTest.WaitForDeploymentScale(
+			p.client.Kube, senderName, p.client.Namespace, int(replicas),
+		)
 	})
 }
 
 func (p *prober) removeSender() {
-	p.log.Infof("Remove of sender pod: %v", senderName)
+	p.log.Info("Remove of sender deployment: ", senderName)
 
-	err := p.client.Kube.Kube.CoreV1().Pods(p.client.Namespace).
+	err := p.client.Kube.Kube.AppsV1().
+		Deployments(p.client.Namespace).
 		Delete(senderName, &metav1.DeleteOptions{})
 	ensure.NoError(err)
 }


### PR DESCRIPTION
This is a possible backport of upstream PR knative#4445. That depends on that upstream PR being merged. I think there's a good chance for it to happen.

If upstream PR will be merged, then nothing more isn't required for 0.18+.

Otherwise, this PR must be also converted to a patch on master branch. Then it must be applied on each release-next, until a better solution is found.

This is required for openshift-knative/serverless-operator#530 (comment)