### PR TITLE
Fix compilation error by removing bad merge

### DIFF
--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -34,7 +34,7 @@ var (
 // Prober is the interface for a prober, which checks the result of the probes when stopped.
 type Prober interface {
 	// Verify will verify prober state after finished has been send
-	Verify(ctx context.Context) ([]error, int)
+	Verify() ([]error, int)
 
 	// Finish send finished event
 	Finish()
@@ -61,7 +61,7 @@ func AssertEventProber(t *testing.T, prober Prober) {
 
 	waitAfterFinished(prober)
 
-	errors, events := prober.Verify(ctx)
+	errors, events := prober.Verify()
 	if len(errors) == 0 {
 		t.Logf("All %d events propagated well", events)
 	} else {


### PR DESCRIPTION
The 0.17.x line of upstream is still using pre 1.18 K8s dependencies, so there's no value in passing the context around everywhere just yet.

/assign @matzew @cardil 