### PR TITLE
Add a compilation check to the CI run to catch issues in PRs

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -11,7 +11,7 @@ export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-tes
 env
 
 # Compile the entire repo to make sure it succeeds.
-go test -run ^$ ./... || exit 1
+go test -tags e2e,preupgrade,postupgrade,postdowngrade,probe -run ^$ ./... || exit 1
 
 scale_up_workers || exit 1
 

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -10,6 +10,9 @@ export TEST_IMAGE_TEMPLATE="${IMAGE_FORMAT//\$\{component\}/knative-eventing-tes
 
 env
 
+# Compile the entire repo to make sure it succeeds.
+go test -run ^$ ./... || exit 1
+
 scale_up_workers || exit 1
 
 failed=0


### PR DESCRIPTION
As per title. This compiles the entire repo (including tests we don't run in CI), to make sure there are no compilation errors missed in CI.