### PR TITLE
Backports and skip tracing 

### DIFF
--- a/cmd/mtbroker/ingress/main.go
+++ b/cmd/mtbroker/ingress/main.go
@@ -127,6 +127,7 @@ func main() {
 		MaxIdleConns:        defaultMaxIdleConnections,
 		MaxIdleConnsPerHost: defaultMaxIdleConnectionsPerHost,
 	}
+	kncloudevents.ConfigureConnectionArgs(&connectionArgs)
 	sender, err := kncloudevents.NewHttpMessageSender(&connectionArgs, "")
 	if err != nil {
 		logger.Fatal("Unable to create message sender", zap.Error(err))

--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -34,16 +34,18 @@ spec:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
         image: ko://knative.dev/eventing/cmd/mtbroker/filter
-        livenessProbe:
+        readinessProbe: &probe
           failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 5
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 5
         resources:
           requests:
             cpu: 100m

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -34,16 +34,18 @@ spec:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
         image: ko://knative.dev/eventing/cmd/mtbroker/ingress
-        livenessProbe:
+        readinessProbe: &probe
           failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 5
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 5
         resources:
           requests:
             cpu: 100m

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -38,6 +38,7 @@ spec:
           image: ko://knative.dev/eventing/cmd/mtping
           env:
             - name: SYSTEM_NAMESPACE
+              value: ''
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/pkg/kncloudevents/http_client.go
+++ b/pkg/kncloudevents/http_client.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kncloudevents
+
+import (
+	nethttp "net/http"
+	"sync"
+	"time"
+
+	"go.opencensus.io/plugin/ochttp"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
+)
+
+const (
+	defaultRetryWaitMin = 1 * time.Second
+	defaultRetryWaitMax = 30 * time.Second
+)
+
+type holder struct {
+	clientMutex    sync.Mutex
+	connectionArgs *ConnectionArgs
+	client         **nethttp.Client
+}
+
+var clientHolder = holder{}
+
+// The used HTTP client is a singleton, so the same http client is reused across all the application.
+// If connection args is modified, client is cleaned and a new one is created.
+func getClient() *nethttp.Client {
+	clientHolder.clientMutex.Lock()
+	defer clientHolder.clientMutex.Unlock()
+
+	if clientHolder.client == nil {
+		// Add connection options to the default transport.
+		var base = nethttp.DefaultTransport.(*nethttp.Transport).Clone()
+		clientHolder.connectionArgs.configureTransport(base)
+		c := &nethttp.Client{
+			// Add output tracing.
+			Transport: &ochttp.Transport{
+				Base:        base,
+				Propagation: tracecontextb3.TraceContextEgress,
+			},
+		}
+		clientHolder.client = &c
+	}
+
+	return *clientHolder.client
+}
+
+// ConfigureConnectionArgs configures the new connection args.
+// The existing client won't be affected, but a new one will be created.
+// Use sparingly, because it might lead to creating a lot of clients, none of them sharing their connection pool!
+func ConfigureConnectionArgs(ca *ConnectionArgs) {
+	clientHolder.clientMutex.Lock()
+	defer clientHolder.clientMutex.Unlock()
+
+	// Check if same config
+	if clientHolder.connectionArgs != nil &&
+		ca != nil &&
+		ca.MaxIdleConns == clientHolder.connectionArgs.MaxIdleConns &&
+		ca.MaxIdleConnsPerHost == clientHolder.connectionArgs.MaxIdleConnsPerHost {
+		return
+	}
+
+	if clientHolder.client != nil {
+		// Let's try to clean up a bit the existing client
+		// Note: this won't remove it nor close it
+		(*clientHolder.client).CloseIdleConnections()
+
+		// Setting client to nil
+		clientHolder.client = nil
+	}
+
+	clientHolder.connectionArgs = ca
+}
+
+// ConnectionArgs allow to configure connection parameters to the underlying
+// HTTP Client transport.
+type ConnectionArgs struct {
+	// MaxIdleConns refers to the max idle connections, as in net/http/transport.
+	MaxIdleConns int
+	// MaxIdleConnsPerHost refers to the max idle connections per host, as in net/http/transport.
+	MaxIdleConnsPerHost int
+}
+
+func (ca *ConnectionArgs) configureTransport(transport *nethttp.Transport) {
+	if ca == nil {
+		return
+	}
+	transport.MaxIdleConns = ca.MaxIdleConns
+	transport.MaxIdleConnsPerHost = ca.MaxIdleConnsPerHost
+}

--- a/pkg/kncloudevents/http_client_test.go
+++ b/pkg/kncloudevents/http_client_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kncloudevents
+
+import (
+	nethttp "net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/plugin/ochttp"
+)
+
+func TestConfigureConnectionArgs(t *testing.T) {
+	// Set connection args
+	ConfigureConnectionArgs(&ConnectionArgs{
+		MaxIdleConnsPerHost: 1000,
+		MaxIdleConns:        1000,
+	})
+	client1 := getClient()
+
+	require.Same(t, getClient(), client1)
+	require.Equal(t, 1000, castToTransport(client1).MaxIdleConns)
+	require.Equal(t, 1000, castToTransport(client1).MaxIdleConnsPerHost)
+
+	// Set other connection args
+	ConfigureConnectionArgs(&ConnectionArgs{
+		MaxIdleConnsPerHost: 2000,
+		MaxIdleConns:        2000,
+	})
+	client2 := getClient()
+
+	require.Same(t, getClient(), client2)
+	require.Equal(t, 2000, castToTransport(client2).MaxIdleConns)
+	require.Equal(t, 2000, castToTransport(client2).MaxIdleConnsPerHost)
+
+	// Try to set the same value and client should not be cleaned up
+	ConfigureConnectionArgs(&ConnectionArgs{
+		MaxIdleConnsPerHost: 2000,
+		MaxIdleConns:        2000,
+	})
+	require.Same(t, getClient(), client2)
+
+	// Set back to nil
+	ConfigureConnectionArgs(nil)
+	client3 := getClient()
+
+	require.Same(t, getClient(), client3)
+	require.Equal(t, nethttp.DefaultTransport.(*nethttp.Transport).MaxIdleConns, castToTransport(client3).MaxIdleConns)
+	require.Equal(t, nethttp.DefaultTransport.(*nethttp.Transport).MaxIdleConnsPerHost, castToTransport(client3).MaxIdleConnsPerHost)
+
+	require.NotSame(t, client1, client2)
+	require.NotSame(t, client1, client3)
+	require.NotSame(t, client2, client3)
+}
+
+func castToTransport(client *nethttp.Client) *nethttp.Transport {
+	return client.Transport.(*ochttp.Transport).Base.(*nethttp.Transport)
+}

--- a/pkg/kncloudevents/message_sender.go
+++ b/pkg/kncloudevents/message_sender.go
@@ -184,6 +184,6 @@ func RetryConfigFromDeliverySpec(spec duckv1.DeliverySpec) (RetryConfig, error) 
 	return retryConfig, nil
 }
 
-func checkRetry(_ context.Context, resp *nethttp.Response, _ error) (bool, error) {
-	return resp != nil && resp.StatusCode >= 300, nil
+func checkRetry(_ context.Context, resp *nethttp.Response, err error) (bool, error) {
+	return !(resp != nil && resp.StatusCode < 300), err
 }

--- a/pkg/kncloudevents/message_sender_test.go
+++ b/pkg/kncloudevents/message_sender_test.go
@@ -18,7 +18,8 @@ package kncloudevents
 
 import (
 	"context"
-	nethttp "net/http"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
@@ -146,14 +147,14 @@ func TestHttpMessageSenderSendWithRetries(t *testing.T) {
 			name: "5 max retry",
 			config: &RetryConfig{
 				RetryMax: 5,
-				CheckRetry: func(ctx context.Context, resp *nethttp.Response, err error) (bool, error) {
+				CheckRetry: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 					return true, nil
 				},
-				Backoff: func(attemptNum int, resp *nethttp.Response) time.Duration {
+				Backoff: func(attemptNum int, resp *http.Response) time.Duration {
 					return time.Millisecond
 				},
 			},
-			wantStatus:   nethttp.StatusServiceUnavailable,
+			wantStatus:   http.StatusServiceUnavailable,
 			wantDispatch: 6,
 			wantErr:      false,
 		},
@@ -161,20 +162,20 @@ func TestHttpMessageSenderSendWithRetries(t *testing.T) {
 			name: "1 max retry",
 			config: &RetryConfig{
 				RetryMax: 1,
-				CheckRetry: func(ctx context.Context, resp *nethttp.Response, err error) (bool, error) {
+				CheckRetry: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 					return true, nil
 				},
-				Backoff: func(attemptNum int, resp *nethttp.Response) time.Duration {
+				Backoff: func(attemptNum int, resp *http.Response) time.Duration {
 					return time.Millisecond
 				},
 			},
-			wantStatus:   nethttp.StatusServiceUnavailable,
+			wantStatus:   http.StatusServiceUnavailable,
 			wantDispatch: 2,
 			wantErr:      false,
 		},
 		{
 			name:         "with no retryConfig",
-			wantStatus:   nethttp.StatusServiceUnavailable,
+			wantStatus:   http.StatusServiceUnavailable,
 			wantDispatch: 1,
 			wantErr:      false,
 		},
@@ -182,24 +183,24 @@ func TestHttpMessageSenderSendWithRetries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var n int32
-			server := httptest.NewServer(nethttp.HandlerFunc(func(writer nethttp.ResponseWriter, request *nethttp.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 				atomic.AddInt32(&n, 1)
 				writer.WriteHeader(tt.wantStatus)
 			}))
 
 			sender := &HttpMessageSender{
-				Client: nethttp.DefaultClient,
+				Client: http.DefaultClient,
 			}
 
-			request, err := nethttp.NewRequest("POST", server.URL, nil)
+			request, err := http.NewRequest("POST", server.URL, nil)
 			assert.Nil(t, err)
 			got, err := sender.SendWithRetries(request, tt.config)
 			if (err != nil) != tt.wantErr || got == nil {
 				t.Errorf("SendWithRetries() error = %v, wantErr %v or got nil", err, tt.wantErr)
 				return
 			}
-			if got.StatusCode != nethttp.StatusServiceUnavailable {
-				t.Errorf("SendWithRetries() got = %v, want %v", got.StatusCode, nethttp.StatusServiceUnavailable)
+			if got.StatusCode != http.StatusServiceUnavailable {
+				t.Errorf("SendWithRetries() got = %v, want %v", got.StatusCode, http.StatusServiceUnavailable)
 				return
 			}
 			if count := int(atomic.LoadInt32(&n)); count != tt.wantDispatch {
@@ -209,35 +210,113 @@ func TestHttpMessageSenderSendWithRetries(t *testing.T) {
 	}
 }
 
+func TestRetriesOnNetworkErrors(t *testing.T) {
+
+	n := int32(10)
+	linear := duckv1.BackoffPolicyLinear
+	target := "127.0.0.1:63468"
+
+	calls := make(chan struct{})
+	defer close(calls)
+
+	nCalls := int32(0)
+
+	cont := make(chan struct{})
+	defer close(cont)
+
+	go func() {
+		for range calls {
+
+			nCalls++
+			// Simulate that the target service is back up.
+			//
+			// First n/2-1 calls we get connection refused since there is no server running.
+			// Now we start a server that responds with a retryable error, so we expect that
+			// the client continues to retry for a different reason.
+			//
+			// The last time we return 200, so we don't expect a new retry.
+			if n/2 == nCalls {
+
+				l, err := net.Listen("tcp", target)
+				assert.Nil(t, err)
+
+				s := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					if n-1 != nCalls {
+						writer.WriteHeader(http.StatusServiceUnavailable)
+						return
+					}
+				}))
+				defer s.Close() //nolint // defers in this range loop won't run unless the channel gets closed
+
+				assert.Nil(t, s.Listener.Close())
+
+				s.Listener = l
+
+				s.Start()
+			}
+			cont <- struct{}{}
+		}
+	}()
+
+	r, err := RetryConfigFromDeliverySpec(duckv1.DeliverySpec{
+		Retry:         pointer.Int32Ptr(n),
+		BackoffPolicy: &linear,
+		BackoffDelay:  pointer.StringPtr("PT0.1S"),
+	})
+	assert.Nil(t, err)
+
+	checkRetry := r.CheckRetry
+
+	r.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		calls <- struct{}{}
+		<-cont
+
+		return checkRetry(ctx, resp, err)
+	}
+
+	req, err := http.NewRequest("POST", "http://"+target, nil)
+	assert.Nil(t, err)
+
+	sender, err := NewHttpMessageSender(nil, "")
+	assert.Nil(t, err)
+
+	_, err = sender.SendWithRetries(req, &r)
+	assert.Nil(t, err)
+
+	// nCalls keeps track of how many times a call to check retry occurs.
+	// Since the number of request are n + 1 and the last one is successful the expected number of calls are n.
+	assert.Equal(t, n, nCalls, "expected %d got %d", n, nCalls)
+}
+
 func TestHTTPMessageSenderSendWithRetriesWithBufferedMessage(t *testing.T) {
 	t.Parallel()
 
 	const wantToSkip = 9
 	config := &RetryConfig{
 		RetryMax: wantToSkip,
-		CheckRetry: func(ctx context.Context, resp *nethttp.Response, err error) (bool, error) {
+		CheckRetry: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 			return true, nil
 		},
-		Backoff: func(attemptNum int, resp *nethttp.Response) time.Duration {
+		Backoff: func(attemptNum int, resp *http.Response) time.Duration {
 			return time.Millisecond * 50 * time.Duration(attemptNum)
 		},
 	}
 
 	var n uint32
-	server := httptest.NewServer(nethttp.HandlerFunc(func(writer nethttp.ResponseWriter, request *nethttp.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		thisReqN := atomic.AddUint32(&n, 1)
 		if thisReqN <= wantToSkip {
-			writer.WriteHeader(nethttp.StatusServiceUnavailable)
+			writer.WriteHeader(http.StatusServiceUnavailable)
 		} else {
-			writer.WriteHeader(nethttp.StatusAccepted)
+			writer.WriteHeader(http.StatusAccepted)
 		}
 	}))
 
 	sender := &HttpMessageSender{
-		Client: nethttp.DefaultClient,
+		Client: http.DefaultClient,
 	}
 
-	request, err := nethttp.NewRequest("POST", server.URL, nil)
+	request, err := http.NewRequest("POST", server.URL, nil)
 	assert.Nil(t, err)
 
 	// Create a message similar to the one we send with channels
@@ -252,8 +331,8 @@ func TestHTTPMessageSenderSendWithRetriesWithBufferedMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SendWithRetries() error = %v, wantErr nil", err)
 	}
-	if got.StatusCode != nethttp.StatusAccepted {
-		t.Fatalf("SendWithRetries() got = %v, want %v", got.StatusCode, nethttp.StatusAccepted)
+	if got.StatusCode != http.StatusAccepted {
+		t.Fatalf("SendWithRetries() got = %v, want %v", got.StatusCode, http.StatusAccepted)
 	}
 	if count := atomic.LoadUint32(&n); count != wantToSkip+1 {
 		t.Fatalf("expected %d count got %d", wantToSkip+1, count)

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -213,20 +213,11 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 	}
 
 	// If there is an event in the response write it to the response
-	statusCode, err := writeResponse(ctx, writer, response, ttl)
+	statusCode, err := h.writeResponse(ctx, writer, response, ttl, target)
 	if err != nil {
 		h.logger.Error("failed to write response", zap.Error(err))
-		// Ok, so writeResponse will return the HttpStatus of the function. That may have
-		// succeeded (200), but it may have returned a malformed event, so if the
-		// function succeeded, convert this to an StatusBadGateway instead to indicate
-		// error. Note that we could just use StatusInternalServerError, but to distinguish
-		// between the two failure cases, we use a different code here.
-		if statusCode == 200 {
-			statusCode = http.StatusBadGateway
-		}
 	}
 	_ = h.reporter.ReportEventCount(reportArgs, statusCode)
-	writer.WriteHeader(statusCode)
 }
 
 func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target string, event *cloudevents.Event, reporterArgs *ReportArgs) (*http.Response, error) {
@@ -262,7 +253,8 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target str
 	return resp, err
 }
 
-func writeResponse(ctx context.Context, writer http.ResponseWriter, resp *http.Response, ttl int32) (int, error) {
+// The return values are the status
+func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter, resp *http.Response, ttl int32, target string) (int, error) {
 	response := cehttp.NewMessageFromHttpResponse(resp)
 	defer response.Finish(nil)
 
@@ -275,19 +267,28 @@ func writeResponse(ctx context.Context, writer http.ResponseWriter, resp *http.R
 		n, _ := response.BodyReader.Read(body)
 		response.BodyReader.Close()
 		if n != 0 {
-			return resp.StatusCode, errors.New("received a non-empty response not recognized as CloudEvent. The response MUST be or empty or a valid CloudEvent")
+			// Note that we could just use StatusInternalServerError, but to distinguish
+			// between the failure cases, we use a different code here.
+			writer.WriteHeader(http.StatusBadGateway)
+			return http.StatusBadGateway, errors.New("received a non-empty response not recognized as CloudEvent. The response MUST be or empty or a valid CloudEvent")
 		}
+		h.logger.Debug("Response doesn't contain a CloudEvent, replying with an empty response", zap.Any("target", target))
+		writer.WriteHeader(resp.StatusCode)
 		return resp.StatusCode, nil
 	}
 
 	event, err := binding.ToEvent(ctx, response)
 	if err != nil {
+		// Like in the above case, we could just use StatusInternalServerError, but to distinguish
+		// between the failure cases, we use a different code here.
+		writer.WriteHeader(http.StatusBadGateway)
 		// Malformed event, reply with err
-		return resp.StatusCode, err
+		return http.StatusBadGateway, err
 	}
 
 	// Reattach the TTL (with the same value) to the response event before sending it to the Broker.
 	if err := broker.SetTTL(event.Context, ttl); err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
 		return http.StatusInternalServerError, fmt.Errorf("failed to reset TTL: %w", err)
 	}
 

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -76,13 +76,11 @@ type FilterResult string
 // NewHandler creates a new Handler and its associated MessageReceiver. The caller is responsible for
 // Start()ing the returned Handler.
 func NewHandler(logger *zap.Logger, triggerLister eventinglisters.TriggerLister, reporter StatsReporter, port int) (*Handler, error) {
-
-	connectionArgs := kncloudevents.ConnectionArgs{
+	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
 		MaxIdleConns:        defaultMaxIdleConnections,
 		MaxIdleConnsPerHost: defaultMaxIdleConnectionsPerHost,
-	}
-
-	sender, err := kncloudevents.NewHttpMessageSender(&connectionArgs, "")
+	})
+	sender, err := kncloudevents.NewHttpMessageSender(nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create message sender: %w", err)
 	}

--- a/pkg/mtbroker/filter/filter_handler_test.go
+++ b/pkg/mtbroker/filter/filter_handler_test.go
@@ -32,15 +32,17 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/google/go-cmp/cmp"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/pkg/apis"
+
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	broker "knative.dev/eventing/pkg/mtbroker"
 	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing"
-	"knative.dev/pkg/apis"
 )
 
 const (
@@ -277,7 +279,7 @@ func TestReceiver(t *testing.T) {
 			expectedEventDispatchTime: true,
 			returnedEvent:             makeDifferentEvent(),
 		},
-		"Returned malformed Cloud Event": {
+		"Returned non empty non event response": {
 			triggers: []*eventingv1beta1.Trigger{
 				makeTrigger(makeTriggerFilterWithAttributes("", "")),
 			},
@@ -285,7 +287,27 @@ func TestReceiver(t *testing.T) {
 			expectedEventCount:        true,
 			expectedEventDispatchTime: true,
 			expectedStatus:            http.StatusBadGateway,
+			response:                  makeNonEmptyResponse(),
+		},
+		"Returned malformed Cloud Event": {
+			triggers: []*eventingv1beta1.Trigger{
+				makeTrigger(makeTriggerFilterWithAttributes("", "")),
+			},
+			expectedDispatch:          true,
+			expectedEventCount:        true,
+			expectedEventDispatchTime: true,
+			expectedStatus:            http.StatusOK,
 			response:                  makeMalformedEventResponse(),
+		},
+		"Returned malformed structured Cloud Event": {
+			triggers: []*eventingv1beta1.Trigger{
+				makeTrigger(makeTriggerFilterWithAttributes("", "")),
+			},
+			expectedDispatch:          true,
+			expectedEventCount:        true,
+			expectedEventDispatchTime: true,
+			expectedStatus:            http.StatusBadGateway,
+			response:                  makeMalformedStructuredEventResponse(),
 		},
 		"Returned empty body 200": {
 			triggers: []*eventingv1beta1.Trigger{
@@ -364,7 +386,11 @@ func TestReceiver(t *testing.T) {
 				tc.request.Header.Set(cehttp.ContentType, event.ApplicationCloudEventsJSON)
 			}
 			responseWriter := httptest.NewRecorder()
-			r.ServeHTTP(responseWriter, tc.request)
+			r.ServeHTTP(&responseWriterWithInvocationsCheck{
+				ResponseWriter: responseWriter,
+				headersWritten: atomic.NewBool(false),
+				t:              t,
+			}, tc.request)
 
 			response := responseWriter.Result()
 
@@ -423,6 +449,19 @@ func TestReceiver(t *testing.T) {
 			}
 		})
 	}
+}
+
+type responseWriterWithInvocationsCheck struct {
+	http.ResponseWriter
+	headersWritten *atomic.Bool
+	t              *testing.T
+}
+
+func (r *responseWriterWithInvocationsCheck) WriteHeader(statusCode int) {
+	if !r.headersWritten.CAS(false, true) {
+		r.t.Fatal("WriteHeader invoked more than once")
+	}
+	r.ResponseWriter.WriteHeader(statusCode)
 }
 
 type mockReporter struct {
@@ -493,15 +532,18 @@ func (h *fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		}
 	}
 	if h.response != nil {
-		defer h.response.Body.Close()
-		body, err := ioutil.ReadAll(h.response.Body)
-		if err != nil {
-			h.t.Fatalf("Unable to read body: %v", err)
+		for k, v := range h.response.Header {
+			resp.Header().Set(k, v[0])
 		}
 		resp.WriteHeader(h.response.StatusCode)
-		resp.Header().Set("Content-Type", "garbage")
-		resp.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
-		resp.Write(body)
+		if h.response.Body != nil {
+			defer h.response.Body.Close()
+			body, err := ioutil.ReadAll(h.response.Body)
+			if err != nil {
+				h.t.Fatal("Unable to read body: ", err)
+			}
+			resp.Write(body)
+		}
 	}
 }
 
@@ -589,7 +631,7 @@ func makeEventWithExtension(extName, extValue string) *cloudevents.Event {
 	return &e
 }
 
-func makeMalformedEventResponse() *http.Response {
+func makeNonEmptyResponse() *http.Response {
 	r := &http.Response{
 		Status:     "200 OK",
 		StatusCode: 200,
@@ -604,6 +646,34 @@ func makeMalformedEventResponse() *http.Response {
 	return r
 }
 
+func makeMalformedEventResponse() *http.Response {
+	r := &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+	}
+	r.Header.Set("Ce-Specversion", "9000.1")
+	return r
+}
+
+func makeMalformedStructuredEventResponse() *http.Response {
+	r := &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+		Header:     make(http.Header),
+	}
+	r.Header.Set("Content-Type", cloudevents.ApplicationCloudEventsJSON)
+
+	return r
+}
+
 func makeEmptyResponse(status int) *http.Response {
 	s := fmt.Sprintf("%d OK", status)
 	r := &http.Response{
@@ -612,10 +682,7 @@ func makeEmptyResponse(status int) *http.Response {
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 		Header:     make(http.Header),
 	}
-	r.Header.Set("Content-Type", "garbage")
-	r.Header.Set("Content-Length", "0")
 	return r
 }

--- a/pkg/mtbroker/ingress/ingress_handler.go
+++ b/pkg/mtbroker/ingress/ingress_handler.go
@@ -96,7 +96,7 @@ func (h *Handler) getChannelAddress(name, namespace string) (string, error) {
 }
 
 func (h *Handler) Start(ctx context.Context) error {
-	return h.Receiver.StartListen(ctx, health.WithLivenessCheck(h))
+	return h.Receiver.StartListen(ctx, health.WithLivenessCheck(health.WithReadinessCheck(h)))
 }
 
 func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -151,10 +151,10 @@ func makeEnv(args *ReceiveAdapterArgs) ([]corev1.EnvVar, error) {
 
 	envs = append(envs, args.Configs.ToEnvVars()...)
 
-	if args.Source.Spec.CloudEventOverrides != nil && args.Source.Spec.CloudEventOverrides.Extensions != nil {
-		ceJson, err := json.Marshal(args.Source.Spec.CloudEventOverrides.Extensions)
+	if args.Source.Spec.CloudEventOverrides != nil {
+		ceJson, err := json.Marshal(args.Source.Spec.CloudEventOverrides)
 		if err != nil {
-			return nil, fmt.Errorf("Failure to marshal cloud event overrides %v: %v", args.Source.Spec.CloudEventOverrides.Extensions, err)
+			return nil, fmt.Errorf("Failure to marshal cloud event overrides %v: %v", args.Source.Spec.CloudEventOverrides, err)
 		}
 		envs = append(envs, corev1.EnvVar{Name: adapter.EnvConfigCEOverrides, Value: string(ceJson)})
 	}

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -162,7 +162,7 @@ func TestMakeReceiveAdapters(t *testing.T) {
 	ceWant := want.DeepCopy()
 	ceWant.Spec.Template.Spec.Containers[0].Env = append(ceWant.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "K_CE_OVERRIDES",
-		Value: `{"1":"one"}`,
+		Value: `{"extensions":{"1":"one"}}`,
 	})
 
 	testCases := map[string]struct {

--- a/test/conformance/broker_tracing_test.go
+++ b/test/conformance/broker_tracing_test.go
@@ -27,5 +27,6 @@ import (
 )
 
 func TestBrokerTracing(t *testing.T) {
+	t.Skip("We for now ignore tracing tests")
 	helpers.BrokerTracingTestHelperWithChannelTestRunner(context.Background(), t, brokerClass, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_tracing_test.go
+++ b/test/conformance/channel_tracing_test.go
@@ -27,5 +27,6 @@ import (
 )
 
 func TestChannelTracingWithReply(t *testing.T) {
+	t.Skip("We for now ignore tracing tests")
 	helpers.ChannelTracingTestHelperWithChannelTestRunner(context.Background(), t, channelTestRunner, testlib.SetupClientOptionNoop)
 }


### PR DESCRIPTION
Backport of:
* https://github.com/knative/eventing/pull/4472
* https://github.com/knative/eventing/pull/4457
* https://github.com/knative/eventing/pull/4468
* https://github.com/knative/eventing/pull/4471
* https://github.com/knative/eventing/pull/4480
* https://github.com/knative/eventing/pull/4483

and, like on 0.18.3: skip traces (they are enabled on `release-next`)
