### PR TITLE
Run the install with the base of 1.11 product

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -132,14 +132,14 @@ function install_serverless(){
   header "Installing Serverless Operator"
   local operator_dir=/tmp/serverless-operator
   local failed=0
-  git clone --branch release-1.8 https://github.com/openshift-knative/serverless-operator.git $operator_dir
+  git clone --branch release-1.11 https://github.com/openshift-knative/serverless-operator.git $operator_dir
   #cp openshift/olm/serverless-operator.clusterserviceversion.yaml $operator_dir/olm-catalog/serverless-operator/manifests/serverless-operator.clusterserviceversion.yaml
-  cp openshift/serverless.bash $operator_dir/hack/lib/serverless.bash
+  #cp openshift/serverless.bash $operator_dir/hack/lib/serverless.bash
   # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
   # to use CI built images, we want pre-built images of k-s-o and k-o-i
   unset OPENSHIFT_BUILD_NAMESPACE
   pushd $operator_dir
-  ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
+  INSTALL_EVENTING="false" ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
   popd
   return $failed
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Using Serverless 1.11 branch, and just install serving with it 