### PR TITLE
Backport #973 to 0.18.4

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -133,9 +133,10 @@ function install_serverless(){
   local operator_dir=/tmp/serverless-operator
   local failed=0
   git clone --branch release-1.11 https://github.com/openshift-knative/serverless-operator.git $operator_dir
-  # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
-  # to use CI built images, we want pre-built images of k-s-o and k-o-i
+  # unset OPENSHIFT_BUILD_NAMESPACE (old CI) and OPENSHIFT_CI (new CI) as its used in serverless-operator's CI
+  # environment as a switch to use CI built images, we want pre-built images of k-s-o and k-o-i
   unset OPENSHIFT_BUILD_NAMESPACE
+  unset OPENSHIFT_CI
   pushd $operator_dir
   INSTALL_EVENTING="false" ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
   popd


### PR DESCRIPTION
unset OPENSHIFT_CI so we use currently promoted CI images for the serverless operator