### PR TITLE
Dockerfile for wathola-fetcher test image

### DIFF
--- a/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+
+ADD wathola-fetcher /usr/bin/wathola-fetcher
+ENTRYPOINT ["/usr/bin/wathola-fetcher"]


### PR DESCRIPTION
As title says.

This follow up on #982 and it's required for openshift-knative/serverless-operator#697