### PR TITLE
[0.18] Adding Chaosduck image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CGO_ENABLED=0
 GOOS=linux
-CORE_IMAGES=$(shell find ./cmd -name main.go ! -path "./cmd/broker/*" ! -path "./cmd/mtbroker/*" | sed 's/main.go//') ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+CORE_IMAGES=$(shell find ./cmd -name main.go ! -path "./cmd/broker/*" ! -path "./cmd/mtbroker/*" | sed 's/main.go//') ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate ./vendor/knative.dev/pkg/leaderelection/chaosduck
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d)
 KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 BRANCH=

--- a/openshift/ci-operator/knative-images/chaosduck/Dockerfile
+++ b/openshift/ci-operator/knative-images/chaosduck/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM openshift/origin-base
+
+ADD chaosduck /usr/bin/chaosduck
+ENTRYPOINT ["/usr/bin/chaosduck"]


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Adding dockerfile for the chaos duck


See also: https://github.com/openshift/release/pull/13827