### PR TITLE
[HEAD] Adding 4.7 CI generator script

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -20,6 +20,7 @@ test -d "$CONFIGDIR" || fail "'$CONFIGDIR' is not a directory"
 CONFIG=$CONFIGDIR/openshift-knative-eventing-release-$VERSION
 CURDIR=$(dirname $0)
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.6 > ${CONFIG}__46.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.7 true > ${CONFIG}__47.yaml
 
 # Append missing lines to the mirror file.
 VER=$(echo $VERSION | sed 's/\./_/;s/\.[0-9]\+$//') # X_Y form of version


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

next time we run `make update-ci` we _automatically get the 4.7 OCP CI runs.....