### PR TITLE
[0.19.2] Skip a test

### DIFF
--- a/test/e2e/broker_with_many_triggers_test.go
+++ b/test/e2e/broker_with_many_triggers_test.go
@@ -40,6 +40,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 }
 
 func TestChannelBasedBrokerWithManyTriggers(t *testing.T) {
+	t.Skip("Flake on OCP 4.7")
 	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
 		for _, version := range unsupportedChannelVersions {
 			if strings.HasSuffix(channel.APIVersion, version) {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

skipping a test that only fails on OCP 4.7, since DEC 16th (without any modification on our end)