### PR TITLE
TestBrokerWithManyTriggers - add specific waits on resources patch

### DIFF
--- a/openshift/patches/017-brokerManyTestsSpecificWaits.patch
+++ b/openshift/patches/017-brokerManyTestsSpecificWaits.patch
@@ -1,0 +1,32 @@
+diff --git a/test/e2e/helpers/broker_test_helper.go b/test/e2e/helpers/broker_test_helper.go
+index 86afc500e..11d449244 100644
+--- a/test/e2e/helpers/broker_test_helper.go
++++ b/test/e2e/helpers/broker_test_helper.go
+@@ -124,6 +124,11 @@ func ChannelBasedBrokerCreator(channel metav1.TypeMeta, brokerClass string) Brok
+ 	}
+ }
+ 
++var podMeta = metav1.TypeMeta{
++	Kind:       "Pod",
++	APIVersion: "v1",
++}
++
+ // If shouldLabelNamespace is set to true this test annotates the testing namespace so that a default broker is created.
+ // It then binds many triggers with different filtering patterns to the broker created by brokerCreator, and sends
+ // different events to the broker's address.
+@@ -260,6 +265,7 @@ func TestBrokerWithManyTriggers(ctx context.Context, t *testing.T, brokerCreator
+ 				subscriberName := "dumper-" + event.String()
+ 				eventTracker, _ := recordevents.StartEventRecordOrFail(ctx, client, subscriberName)
+ 				eventTrackers[subscriberName] = eventTracker
++				client.WaitForResourceReadyOrFail(subscriberName, &podMeta)
+ 				// Create trigger.
+ 				triggerName := "trigger-" + event.String()
+ 				client.CreateTriggerOrFailV1Beta1(triggerName,
+@@ -267,6 +273,7 @@ func TestBrokerWithManyTriggers(ctx context.Context, t *testing.T, brokerCreator
+ 					resources.WithAttributesTriggerFilterV1Beta1(event.Source, event.Type, event.Extensions),
+ 					resources.WithBrokerV1Beta1(brokerName),
+ 				)
++				client.WaitForResourceReadyOrFail(triggerName, testlib.TriggerTypeMeta)
+ 			}
+ 			// Wait for all test resources to become ready before sending the events.
+ 			client.WaitForAllTestResourcesReadyOrFail(ctx)


### PR DESCRIPTION
Checking to see if CI runs need to have more explicit waits on each resource