### PR TITLE
Using 1.15 on our linux container

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
+FROM registry.ci.openshift.org/openshift/release:golang-1.15
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Upstream did bump to 1.15 [earlier today](https://github.com/knative/eventing/pull/4795/commits/e69815dda133e27190835874eef203af1305369d) on `HEAD`, doing same here

Our serving fork also uses the 1.15 as the base since a few days 