### PR TITLE
Run mirror-to-upstream-branch.sh script from nightly mirror

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -6,6 +6,9 @@
 set -e
 REPO_NAME=`basename $(git rev-parse --show-toplevel)`
 
+# Check if there's an upstream release we need to mirror downstream
+openshift/release/mirror-upstream-branches.sh
+
 # Reset release-next to upstream/master.
 git fetch upstream master
 git checkout upstream/master -B release-next


### PR DESCRIPTION
Most runs this should return 0 (and no error) as we have no new
upstream branches to mirror