### PR TITLE
Expose runmaintest for upgrades

### DIFF
--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"os"
+	"testing"
+
+	"knative.dev/eventing/test"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+// RunMainTest initializes the flags to run the eventing upgrade tests, and runs the channel tests.
+// This function needs to be exposed, so that test cases in other repositories can call the upgrade
+// main tests in eventing.
+func RunMainTest(m *testing.M) {
+	test.InitializeEventingFlags()
+	channelTestRunner = testlib.ComponentsTestRunner{
+		ComponentFeatureMap: testlib.ChannelFeatureMap,
+		ComponentsToTest:    test.EventingFlags.Channels,
+	}
+	os.Exit(m.Run())
+}

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -19,12 +19,9 @@ limitations under the License.
 package upgrade
 
 import (
-	"os"
 	"testing"
 
 	"go.uber.org/zap"
-	"knative.dev/eventing/test"
-	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/upgrade/installation"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 )
@@ -70,10 +67,5 @@ func newUpgradeConfig(t *testing.T) pkgupgrade.Configuration {
 }
 
 func TestMain(m *testing.M) {
-	test.InitializeEventingFlags()
-	channelTestRunner = testlib.ComponentsTestRunner{
-		ComponentFeatureMap: testlib.ChannelFeatureMap,
-		ComponentsToTest:    test.EventingFlags.Channels,
-	}
-	os.Exit(m.Run())
+	RunMainTest(m)
 }


### PR DESCRIPTION
This will be required for upgrades in serverless-operator. Without this patch the variable `channelTestRunner` is not accessible.

This change should be there automatically when we pull 0.21.x branch from upstream.