### PR TITLE
[0.20 backport] Timezone not added to schedule in runner.go #5058 (#5059)

### DIFF
--- a/pkg/adapter/mtping/runner.go
+++ b/pkg/adapter/mtping/runner.go
@@ -93,8 +93,13 @@ func (a *cronJobsRunner) AddSchedule(source *v1beta2.PingSource) cron.EntryID {
 		ResourceGroup: resourceGroup,
 	}
 
+	schedule := source.Spec.Schedule
+	if source.Spec.Timezone != "" {
+		schedule = "CRON_TZ=" + source.Spec.Timezone + " " + schedule
+	}
+
 	ctx = kncloudevents.ContextWithMetricTag(ctx, metricTag)
-	id, _ := a.cron.AddFunc(source.Spec.Schedule, a.cronTick(ctx, event))
+	id, _ := a.cron.AddFunc(schedule, a.cronTick(ctx, event))
 	return id
 }
 


### PR DESCRIPTION
https://github.com/knative/eventing/issues/5058
Signed-off-by: rickr <cr22rc@users.noreply.github.com>


/hold