### PR TITLE
source.crd controller: filter out non duck crds

### DIFF
--- a/pkg/reconciler/source/crd/crd_test.go
+++ b/pkg/reconciler/source/crd/crd_test.go
@@ -158,6 +158,23 @@ func TestAllCases(t *testing.T) {
 			Key: crdName,
 			Ctx: ctx,
 		},
+		{
+			Name: "crd missing duck label",
+			Objects: []runtime.Object{
+				NewCustomResourceDefinition(crdName,
+					WithCustomResourceDefinitionGroup(crdGroup),
+					WithCustomResourceDefinitionNames(apiextensionsv1.CustomResourceDefinitionNames{
+						Kind:   crdKind,
+						Plural: crdPlural,
+					}),
+					WithCustomResourceDefinitionVersions([]apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name:   crdVersionServed,
+						Served: true,
+					}})),
+			},
+			Key: crdName,
+			Ctx: ctx,
+		},
 	}
 
 	logger := logtesting.TestLogger(t)
@@ -184,9 +201,7 @@ func TestControllerRunning(t *testing.T) {
 			Name: "reconcile succeeded",
 			Objects: []runtime.Object{
 				NewCustomResourceDefinition(crdName,
-					WithCustomResourceDefinitionLabels(map[string]string{
-						sources.SourceDuckLabelKey: sources.SourceDuckLabelValue,
-					}),
+					WithCustomResourceDefinitionLabels(map[string]string{sources.SourceDuckLabelKey: sources.SourceDuckLabelValue}),
 					WithCustomResourceDefinitionGroup(crdGroup),
 					WithCustomResourceDefinitionNames(apiextensionsv1.CustomResourceDefinitionNames{
 						Kind:   crdKind,


### PR DESCRIPTION
knative.dev/pkg controller runtime doesn't allow for global level
resync and leaderelection functions to filter out objects set by
filter funcs.  In the case of the crd controller -- this means our
reconciliation process picks up unrelated objets to try and create
duck controllers.  Add an extra check in the reconcile process
equivalent to the informer filterFunc