### PR TITLE
Upstream did drop the v1beta, correcting our test execution for channels

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -190,7 +190,7 @@ function run_e2e_tests(){
   local test_name="${1:-}"
   local run_command=""
   local failed=0
-  local channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel
+  local channels=messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel
   local sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource
 
   local common_opts=" -channels=$channels -sources=$sources --kubeconfig $KUBECONFIG --imagetemplate $TEST_IMAGE_TEMPLATE"
@@ -216,7 +216,7 @@ function run_conformance_tests(){
   local test_name="${1:-}"
   local run_command=""
   local failed=0
-  local channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel
+  local channels=messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel
   local sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource
 
   local common_opts=" -channels=$channels -sources=$sources --kubeconfig $KUBECONFIG --imagetemplate $TEST_IMAGE_TEMPLATE"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>