### PR TITLE
[SRVKS-720] Mute noisy metrics controller & webhook

### DIFF
--- a/vendor/knative.dev/pkg/controller/stats_reporter.go
+++ b/vendor/knative.dev/pkg/controller/stats_reporter.go
@@ -197,7 +197,7 @@ func (r *reporter) ReportReconcile(duration time.Duration, success string, key t
 		return err
 	}
 
-	metrics.RecordBatch(ctx, reconcileCountStat.M(1),
-		reconcileLatencyStat.M(duration.Milliseconds()))
+	// TODO skonto: fix latency histogram
+	metrics.RecordBatch(ctx, reconcileCountStat.M(1))
 	return nil
 }

--- a/vendor/knative.dev/pkg/webhook/stats_reporter.go
+++ b/vendor/knative.dev/pkg/webhook/stats_reporter.go
@@ -99,9 +99,8 @@ func (r *reporter) ReportRequest(req *admissionv1.AdmissionRequest, resp *admiss
 		return err
 	}
 
-	metrics.RecordBatch(ctx, requestCountM.M(1),
-		// Convert time.Duration in nanoseconds to milliseconds
-		responseTimeInMsecM.M(float64(d.Milliseconds())))
+	// TODO skonto: fix latency histogram
+	metrics.Record(ctx, requestCountM.M(1))
 	return nil
 }
 


### PR DESCRIPTION
Shutdown these noisy metrics (they are in TODO status because they are useful), however I spotted a worse issue. Check my comment [here](https://github.com/knative/serving/issues/11248#issuecomment-826380392). 

/cc @matzew  @schmidtd.