### PR TITLE
Upstream removed the v1alpha2 tests

### DIFF
--- a/openshift/patches/014-sinkbinding_tests_skip.patch
+++ b/openshift/patches/014-sinkbinding_tests_skip.patch
@@ -1,15 +1,3 @@
-diff --git a/test/e2e/source_sinkbinding_v1alpha2_test.go b/test/e2e/source_sinkbinding_v1alpha2_test.go
-index 8e8e0c037..9aa5cc9fb 100644
---- a/test/e2e/source_sinkbinding_v1alpha2_test.go
-+++ b/test/e2e/source_sinkbinding_v1alpha2_test.go
-@@ -122,6 +122,7 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
- }
- 
- func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
-+	t.Skip("SRVKE-500: Skipping since we set bindings to inclusion")
- 	const (
- 		sinkBindingName = "e2e-sink-binding"
- 		deploymentName  = "e2e-sink-binding-cronjob"
 diff --git a/test/e2e/source_sinkbinding_v1beta1_test.go b/test/e2e/source_sinkbinding_v1beta1_test.go
 index 0df34b42e..086a5ba40 100644
 --- a/test/e2e/source_sinkbinding_v1beta1_test.go


### PR DESCRIPTION
see: https://github.com/knative/eventing/pull/5318

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>