### PR TITLE
Using logger.info instead of header_text

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -112,7 +112,7 @@ EOF
 }
 
 function enable_eventing_tracing {
-  header_text "Configuring tracing for Eventing"
+  logger.info "Configuring tracing for Eventing"
 
   cat <<EOF | oc apply -f - || return $?
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

the enabling traces still uses the `header_text`, instead of `logger.info` calls