### PR TITLE
[main] using logger.info instead of header_text (#1240)

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -112,7 +112,7 @@ EOF
 }
 
 function enable_eventing_tracing {
-  header_text "Configuring tracing for Eventing"
+  logger.info "Configuring tracing for Eventing"
 
   cat <<EOF | oc apply -f - || return $?
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

bringing #1240 to `main` branch