### PR TITLE
[0.20] Use the latest of OCP Serverless on 0.20 branch

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -132,7 +132,7 @@ function install_serverless(){
   header "Installing Serverless Operator"
   local operator_dir=/tmp/serverless-operator
   local failed=0
-  git clone --branch release-1.13 https://github.com/openshift-knative/serverless-operator.git $operator_dir
+  git clone --branch release-1.14 https://github.com/openshift-knative/serverless-operator.git $operator_dir
   # unset OPENSHIFT_BUILD_NAMESPACE (old CI) and OPENSHIFT_CI (new CI) as its used in serverless-operator's CI
   # environment as a switch to use CI built images, we want pre-built images of k-s-o and k-o-i
   unset OPENSHIFT_BUILD_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title