### PR TITLE
Defaulting to MTChannelBasedBroker

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -203,7 +203,6 @@ function run_e2e_tests(){
 
   go_test_e2e -timeout=50m -parallel=20 ./test/e2e \
     "$run_command" \
-    -brokerclass=MTChannelBasedBroker \
     $common_opts || failed=$?
 
   return $failed
@@ -229,7 +228,6 @@ function run_conformance_tests(){
 
   go_test_e2e -timeout=30m -parallel=12 ./test/conformance \
     "$run_command" \
-    -brokerclass=MTChannelBasedBroker \
     $common_opts || failed=$?
 
   return $failed


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

No explict broker class, we default to `MTChannelBasedBroker`