### PR TITLE
[main] Imc generation patch

### DIFF
--- a/openshift/patches/019-remove-tracing-observability-yamls.patch
+++ b/openshift/patches/019-remove-tracing-observability-yamls.patch
@@ -1,0 +1,144 @@
+diff --git a/config/channels/in-memory-channel/configmaps/observability.yaml b/config/channels/in-memory-channel/configmaps/observability.yaml
+deleted file mode 100644
+index cad2fc51e..000000000
+--- a/config/channels/in-memory-channel/configmaps/observability.yaml
++++ /dev/null
+@@ -1,73 +0,0 @@
+-# Copyright 2021 The Knative Authors
+-
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     https://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-apiVersion: v1
+-kind: ConfigMap
+-metadata:
+-  name: config-observability
+-  namespace: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: devel
+-    knative.dev/config-propagation: original
+-    knative.dev/config-category: eventing
+-  annotations:
+-    knative.dev/example-checksum: "f46cf09d"
+-data:
+-  _example: |
+-    ################################
+-    #                              #
+-    #    EXAMPLE CONFIGURATION     #
+-    #                              #
+-    ################################
+-
+-    # This block is not actually functional configuration,
+-    # but serves to illustrate the available configuration
+-    # options and document them in a way that is accessible
+-    # to users that `kubectl edit` this config map.
+-    #
+-    # These sample configuration options may be copied out of
+-    # this example block and unindented to be in the data block
+-    # to actually change the configuration.
+-
+-    # metrics.backend-destination field specifies the system metrics destination.
+-    # It supports either prometheus (the default) or stackdriver.
+-    # Note: Using stackdriver will incur additional charges
+-    metrics.backend-destination: prometheus
+-
+-    # metrics.request-metrics-backend-destination specifies the request metrics
+-    # destination. If non-empty, it enables queue proxy to send request metrics.
+-    # Currently supported values: prometheus, stackdriver.
+-    metrics.request-metrics-backend-destination: prometheus
+-
+-    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+-    # field is optional. When running on GCE, application default credentials will be
+-    # used if this field is not provided.
+-    metrics.stackdriver-project-id: "<your stackdriver project id>"
+-
+-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+-    # Stackdriver using "global" resource type and custom metric type if the
+-    # metrics are not supported by "knative_broker", "knative_trigger", and "knative_source" resource types.
+-    # Setting this flag to "true" could cause extra Stackdriver charge.
+-    # If metrics.backend-destination is not Stackdriver, this is ignored.
+-    metrics.allow-stackdriver-custom-metrics: "false"
+-
+-    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+-    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+-    # enabled, the Knative Eventing pods expose the profiling data on an alternate HTTP port 8008.
+-    # The HTTP context root for profiling is then /debug/pprof/.
+-    profiling.enable: "false"
+-
+-    # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
+-    # a failure to send a cloud event to the sink.
+-    sink-event-error-reporting.enable: "false"
+diff --git a/config/channels/in-memory-channel/configmaps/tracing.yaml b/config/channels/in-memory-channel/configmaps/tracing.yaml
+deleted file mode 100644
+index a699f1321..000000000
+--- a/config/channels/in-memory-channel/configmaps/tracing.yaml
++++ /dev/null
+@@ -1,59 +0,0 @@
+-# Copyright 2021 The Knative Authors
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     https://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-
+-apiVersion: v1
+-kind: ConfigMap
+-metadata:
+-  name: config-tracing
+-  namespace: knative-eventing
+-  labels:
+-    eventing.knative.dev/release: devel
+-    knative.dev/config-propagation: original
+-    knative.dev/config-category: eventing
+-  annotations:
+-    knative.dev/example-checksum: "4002b4c2"
+-data:
+-  _example: |
+-    ################################
+-    #                              #
+-    #    EXAMPLE CONFIGURATION     #
+-    #                              #
+-    ################################
+-    # This block is not actually functional configuration,
+-    # but serves to illustrate the available configuration
+-    # options and document them in a way that is accessible
+-    # to users that `kubectl edit` this config map.
+-    #
+-    # These sample configuration options may be copied out of
+-    # this example block and unindented to be in the data block
+-    # to actually change the configuration.
+-    #
+-    # This may be "zipkin" or "stackdriver", the default is "none"
+-    backend: "none"
+-
+-    # URL to zipkin collector where traces are sent.
+-    # This must be specified when backend is "zipkin"
+-    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+-
+-    # The GCP project into which stackdriver metrics will be written
+-    # when backend is "stackdriver".  If unspecified, the project-id
+-    # is read from GCP metadata when running on GCP.
+-    stackdriver-project-id: "my-project"
+-
+-    # Enable zipkin debug mode. This allows all spans to be sent to the server
+-    # bypassing sampling.
+-    debug: "false"
+-
+-    # Percentage (0-1) of requests to trace
+-    sample-rate: "0.1"

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -22,8 +22,34 @@ resolve_resources config/sugar/ crd-sugar-resolved.yaml $image_prefix $tag
 cat crd-sugar-resolved.yaml >> $output_file
 rm crd-sugar-resolved.yaml
 
-# InMemoryChannel CRD
+# InMemoryChannel folders...
+# The root folder
 resolve_resources config/channels/in-memory-channel/ crd-channel-resolved.yaml $image_prefix $tag
+cat crd-channel-resolved.yaml >> $output_file
+rm crd-channel-resolved.yaml
+
+# The configmaps folder
+resolve_resources config/channels/in-memory-channel/configmaps crd-channel-resolved.yaml $image_prefix $tag
+cat crd-channel-resolved.yaml >> $output_file
+rm crd-channel-resolved.yaml
+
+# The deployments folder
+resolve_resources config/channels/in-memory-channel/deployments crd-channel-resolved.yaml $image_prefix $tag
+cat crd-channel-resolved.yaml >> $output_file
+rm crd-channel-resolved.yaml
+
+# The resources folder
+resolve_resources config/channels/in-memory-channel/resources crd-channel-resolved.yaml $image_prefix $tag
+cat crd-channel-resolved.yaml >> $output_file
+rm crd-channel-resolved.yaml
+
+# The roles folder
+resolve_resources config/channels/in-memory-channel/roles crd-channel-resolved.yaml $image_prefix $tag
+cat crd-channel-resolved.yaml >> $output_file
+rm crd-channel-resolved.yaml
+
+# The webhooks folder
+resolve_resources config/channels/in-memory-channel/webhooks crd-channel-resolved.yaml $image_prefix $tag
 cat crd-channel-resolved.yaml >> $output_file
 rm crd-channel-resolved.yaml
 


### PR DESCRIPTION
Getting back the IMC content... after symlnks got removed upsream

also removing the duplicated tracing/observabilty yamls