### PR TITLE
[RELEASE-v0.21.0] Use new label for defining a cluster-local Knative Service

### DIFF
--- a/test/upgrade/prober/forwarder.go
+++ b/test/upgrade/prober/forwarder.go
@@ -68,7 +68,7 @@ func (p *prober) forwarderKService(name, namespace string) *unstructured.Unstruc
 			"name":      name,
 			"namespace": namespace,
 			"labels": map[string]string{
-				"serving.knative.dev/visibility": "cluster-local",
+				"networking.knative.dev/visibility": "cluster-local",
 			},
 		},
 		"spec": map[string]interface{}{


### PR DESCRIPTION
As per title. This fixes the wrong label for cluster-local services and unblocks serverless-operator CIs upgrade tests.