### PR TITLE
Fixing some scripts for 0.23 (and later)

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -19,7 +19,7 @@ promotion:
   disabled: $promotion_disabled
   cluster: https://api.ci.openshift.org
   namespace: openshift
-  name: $branch
+  name: $branch.0
 base_images:
   base:
     name: '$openshift'

--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -19,7 +19,7 @@ EOF
 
 # Deduce branch name and X.Y.Z version.
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-VERSION=$(echo $BRANCH | sed -E 's/^.*(v[0-9]+\.[0-9]+\.[0-9]+|next)|.*/\1/')
+VERSION=$(echo $BRANCH | sed -E 's/^.*(v[0-9]+\.[0-9]+|next)|.*/\1/')
 test -n "$VERSION" || fail "'$BRANCH' is not a release branch"
 
 # Set up variables for important locations in the openshift/release repo.


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

We will create CI config for `release-v X.Z` branches, but start the promotion with `release-v X.Y.Z` due to the coupling of the "upstream manifest" download on the serverless operator.


* `generate-ci-config.sh` the branch name (e.g. `release-v0.23`) is used as promotion name, with a static `.0` at the end (to match the upstream version schema, b/c: https://github.com/openshift-knative/serverless-operator/blob/main/olm-catalog/serverless-operator/project.yaml#L29
* `update-ci.sh ` the script to trigger `make update-ci` checks the name of the branch, and was complaining about the new format (e.g. `releaes-0.23`)
