### PR TITLE
A new image to replace

### DIFF
--- a/openshift/patches/018-rekt-test-apiserversource_data_plane.patch
+++ b/openshift/patches/018-rekt-test-apiserversource_data_plane.patch
@@ -1,0 +1,13 @@
+diff --git a/test/rekt/features/apiserversource/data_plane.go b/test/rekt/features/apiserversource/data_plane.go
+index 037281409..1c7a734dd 100644
+--- a/test/rekt/features/apiserversource/data_plane.go
++++ b/test/rekt/features/apiserversource/data_plane.go
+@@ -37,7 +37,7 @@ import (
+ )
+ 
+ const (
+-	exampleImage = "ko://knative.dev/eventing/test/test_images/print"
++	exampleImage = "registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-print"
+ )
+ 
+ func DataPlane_SinkTypes() *feature.FeatureSet {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

There was a new ko-image reference added in https://github.com/knative/eventing/pull/5348

On OCP we are not using `ko apply`, so we have to replace the `ko://` references with our own images.

The `print` image does already exist on our registry, b/c it's older, so we can just replace it. We do NOT need to setup up an extra image build etc

/assign @lberk
/cc @aliok 