### PR TITLE
Adding timeput for e2e jobs to the generator script

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -43,6 +43,7 @@ tests:
       resources:
         requests:
           cpu: 100m
+      timeout: 4h0m0s
     workflow: ipi-aws
 - as: conformance-aws-ocp-${openshift//./}
   steps:
@@ -55,6 +56,7 @@ tests:
       resources:
         requests:
           cpu: 100m
+      timeout: 4h0m0s
     workflow: ipi-aws
 - as: reconciler-aws-ocp-${openshift//./}
   steps:
@@ -67,6 +69,7 @@ tests:
       resources:
         requests:
           cpu: 100m
+      timeout: 4h0m0s
     workflow: ipi-aws
 - as: e2e-aws-ocp-${openshift//./}-continuous
   cron: 0 */12 * * 1-5
@@ -80,6 +83,7 @@ tests:
       resources:
         requests:
           cpu: 100m
+      timeout: 4h0m0s
     workflow: ipi-aws
 resources:
   '*':


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

The `make update-ci` _TARGET_ generates the config for the `openshift/release` repo.

Recently we have increased the default timeout to 4h:
https://github.com/openshift/release/commit/6c3b6e796434f8612f3ac4b543741d31e3f24fb8

This adds those values directly to the generator script