### PR TITLE
[Release-v0.22.0][Backport] Make Channel metrics generic enough for eventing-kafka

### DIFF
--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -190,7 +190,7 @@ func createMessageReceiverFunction(f *FanoutMessageHandler) func(context.Context
 				ctx = trace.NewContext(context.Background(), s)
 				// Any returned error is already logged in f.dispatch().
 				dispatchResultForFanout := f.dispatch(ctx, subs, m, h)
-				_ = parseFanoutResultAndReportMetrics(dispatchResultForFanout, *r, *args)
+				_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)
 			}(bufferedMessage, additionalHeaders, parentSpan, &f.reporter, &reportArgs)
 			return nil
 		}
@@ -217,7 +217,7 @@ func createMessageReceiverFunction(f *FanoutMessageHandler) func(context.Context
 		reportArgs.EventType = string(te)
 		reportArgs.Ns = ref.Namespace
 		dispatchResultForFanout := f.dispatch(ctx, subs, bufferedMessage, additionalHeaders)
-		return parseFanoutResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
+		return ParseDispatchResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
 	}
 }
 
@@ -225,7 +225,8 @@ func (f *FanoutMessageHandler) ServeHTTP(response nethttp.ResponseWriter, reques
 	f.receiver.ServeHTTP(response, request)
 }
 
-func parseFanoutResultAndReportMetrics(result dispatchResult, reporter channel.StatsReporter, reportArgs channel.ReportArgs) error {
+// ParseDispatchResultAndReportMetric processes the dispatch result and records the related channel metrics with the appropriate context
+func ParseDispatchResultAndReportMetrics(result dispatchResult, reporter channel.StatsReporter, reportArgs channel.ReportArgs) error {
 	if result.info != nil && result.info.Time > channel.NoDuration {
 		if result.info.ResponseCode > channel.NoResponse {
 			_ = reporter.ReportEventDispatchTime(&reportArgs, result.info.ResponseCode, result.info.Time)

--- a/pkg/channel/stats_reporter.go
+++ b/pkg/channel/stats_reporter.go
@@ -30,19 +30,19 @@ import (
 )
 
 var (
-	// eventCountM is a counter which records the number of events received
-	// by the in-memory Channel.
+	// eventCountM is a counter which records the number of events dispatched
+	// by the channel.
 	eventCountM = stats.Int64(
 		"event_count",
-		"Number of events dispatched by the in-memory channel",
+		"Number of events dispatched by the channel",
 		stats.UnitDimensionless,
 	)
 
-	// dispatchTimeInMsecM records the Time spent dispatching an event to
-	// a Channel, in milliseconds.
+	// dispatchTimeInMsecM records the time spent by the channel dispatching an event to
+	// to subscribers, in milliseconds.
 	dispatchTimeInMsecM = stats.Float64(
 		"event_dispatch_latencies",
-		"The Time spent dispatching an event from a in-memoryChannel",
+		"The time spent by the channel dispatching an event",
 		stats.UnitMilliseconds,
 	)
 


### PR DESCRIPTION
Backport of: https://github.com/knative/eventing/pull/5478 & https://github.com/knative/eventing/pull/5481

/cc @matzew 