### PR TITLE
Patch the rekt for 0.24 too

### DIFF
--- a/vendor/knative.dev/reconciler-test/pkg/images/ko.go
+++ b/vendor/knative.dev/reconciler-test/pkg/images/ko.go
@@ -16,20 +16,7 @@ limitations under the License.
 
 package images
 
-import (
-	"fmt"
-	"os"
-)
-
 // Use ko to publish the image.
 func KoPublish(path string) (string, error) {
-	platform := os.Getenv("PLATFORM")
-	if len(platform) > 0 {
-		platform = " --platform=" + platform
-	}
-	out, err := runCmd(fmt.Sprintf("ko publish%s -B %s", platform, path))
-	if err != nil {
-		return "", err
-	}
-	return out, nil
+	return "", nil
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


Bringing patch to 0.24 that was done on `main`/`release-next` .....
See https://github.com/openshift/knative-eventing/pull/1341