### PR TITLE
Adding patch for OCP 4.9, like done on older release branches (0.24+)

### DIFF
--- a/openshift/patches/005-subresource.patch
+++ b/openshift/patches/005-subresource.patch
@@ -1,0 +1,20 @@
+diff --git a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+index d84878d7c..522336cba 100644
+--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
++++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+@@ -1158,6 +1158,15 @@ type ManagedFieldsEntry struct {
+ 	// FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+ 	// +optional
+ 	FieldsV1 *FieldsV1 `json:"fieldsV1,omitempty" protobuf:"bytes,7,opt,name=fieldsV1"`
++
++	// Subresource is the name of the subresource used to update that object, or
++	// empty string if the object was updated through the main resource. The
++	// value of this field is used to distinguish between managers, even if they
++	// share the same name. For example, a status update will be distinct from a
++	// regular update using the same manager name.
++	// Note that the APIVersion field is not related to the Subresource field and
++	// it always corresponds to the version of the main resource.
++	Subresource string `json:"subresource,omitempty" protobuf:"bytes,8,opt,name=subresource"`
+ }
+ 
+ // ManagedFieldsOperationType is the type of operation which lead to a ManagedFieldsEntry being created.


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title - similar to https://github.com/openshift/knative-eventing/pull/1361 (as on main)