### PR TITLE
[release-v0.24] Do not set TEST_IMAGE_TEMPLATE in e2e-commons.sh

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -5,9 +5,7 @@ export SYSTEM_NAMESPACE=$EVENTING_NAMESPACE
 export ZIPKIN_NAMESPACE=$EVENTING_NAMESPACE
 export KNATIVE_DEFAULT_NAMESPACE=$EVENTING_NAMESPACE
 export CONFIG_TRACING_CONFIG="test/config/config-tracing.yaml"
-
-if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-  export TEST_IMAGE_TEMPLATE=$(cat <<-END
+export EVENTING_TEST_IMAGE_TEMPLATE=$(cat <<-END
 {{- with .Name }}
 {{- if eq . "event-flaker"}}$KNATIVE_EVENTING_TEST_EVENT_FLAKER{{end -}}
 {{- if eq . "event-library"}}$KNATIVE_EVENTING_TEST_EVENT_LIBRARY{{end -}}
@@ -25,15 +23,6 @@ if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
 {{end -}}
 END
 )
-elif [ -n "${TEMPLATE:-}" ]; then
-  export TEST_IMAGE_TEMPLATE="$TEMPLATE"
-elif [ -n "${DOCKER_REPO_OVERRIDE:-}" ]; then
-  export TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
-elif [ -n "${BRANCH:-}" ]; then
-  export TEST_IMAGE_TEMPLATE="registry.ci.openshift.org/openshift/${BRANCH}:knative-eventing-test-{{.Name}}"
-else
-  export TEST_IMAGE_TEMPLATE="registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-{{.Name}}"
-fi
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"

--- a/openshift/e2e-conformance-tests.sh
+++ b/openshift/e2e-conformance-tests.sh
@@ -6,6 +6,8 @@ source "$(dirname "$0")/e2e-common.sh"
 
 set -Eeuox pipefail
 
+export TEST_IMAGE_TEMPLATE="${EVENTING_TEST_IMAGE_TEMPLATE}"
+
 env
 
 failed=0

--- a/openshift/e2e-rekt-tests.sh
+++ b/openshift/e2e-rekt-tests.sh
@@ -6,6 +6,8 @@ source "$(dirname "$0")/e2e-common.sh"
 
 set -Eeuox pipefail
 
+export TEST_IMAGE_TEMPLATE="${EVENTING_TEST_IMAGE_TEMPLATE}"
+
 env
 
 failed=0

--- a/openshift/e2e-tests-local.sh
+++ b/openshift/e2e-tests-local.sh
@@ -6,6 +6,16 @@ source "$(dirname "$0")/e2e-common.sh"
 
 set -Eeuox pipefail
 
+if [ -n "${TEMPLATE:-}" ]; then
+  export TEST_IMAGE_TEMPLATE="$TEMPLATE"
+elif [ -n "${DOCKER_REPO_OVERRIDE:-}" ]; then
+  export TEST_IMAGE_TEMPLATE="${DOCKER_REPO_OVERRIDE}/{{.Name}}"
+elif [ -n "${BRANCH:-}" ]; then
+  export TEST_IMAGE_TEMPLATE="registry.ci.openshift.org/openshift/${BRANCH}:knative-eventing-test-{{.Name}}"
+else
+  export TEST_IMAGE_TEMPLATE="registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-{{.Name}}"
+fi
+
 env
 
 failed=0

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -6,6 +6,8 @@ source "$(dirname "$0")/e2e-common.sh"
 
 set -Eeuox pipefail
 
+export TEST_IMAGE_TEMPLATE="${EVENTING_TEST_IMAGE_TEMPLATE}"
+
 env
 
 failed=0


### PR DESCRIPTION
Fixes the script failures in https://github.com/openshift-knative/serverless-operator/pull/1153

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

