### PR TITLE
[main] Go with latest for zipkin... same like on Serverless Product repo

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:2.13.0
+        image: docker.io/openzipkin/zipkin:latest
         ports:
         - containerPort: 9411
         env:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

with this we are aligned like here:
https://github.com/openshift-knative/serverless-operator/blob/18b4a322177bb28fb910614d4eedde8b324096df/hack/lib/tracing.bash#L43

/assign @cardil 