### PR TITLE
Use version ghcr for zipkin:2

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:latest
+        image: ghcr.io/openzipkin/zipkin:2
         ports:
         - containerPort: 9411
         env:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title

/assign @cardil 