### PR TITLE
Vendor serving's k8s min version patch

### DIFF
--- a/openshift/patches/005-k8s-min.patch
+++ b/openshift/patches/005-k8s-min.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/knative.dev/pkg/version/version.go b/vendor/knative.dev/pkg/version/version.go
+index 3cbd846ea..81b1ba46a 100644
+--- a/vendor/knative.dev/pkg/version/version.go
++++ b/vendor/knative.dev/pkg/version/version.go
+@@ -33,7 +33,7 @@ const (
+ 	// NOTE: If you are changing this line, please also update the minimum kubernetes
+ 	// version listed here:
+ 	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
+-	defaultMinimumVersion = "v1.20.0"
++	defaultMinimumVersion = "v1.19.0"
+ )
+ 
+ func getMinimumVersion() string {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Bringing https://github.com/openshift/knative-eventing/pull/1470  to main stash....