### PR TITLE
We are now 1.0+ ...

### DIFF
--- a/openshift/release/mirror-upstream-branches.sh
+++ b/openshift/release/mirror-upstream-branches.sh
@@ -17,8 +17,8 @@ cat >> "$TMPDIR"/midstream_branches <<EOF
 0.3
 EOF
 
-git branch --list -a "upstream/release-0.*" | cut -f3 -d'/' | cut -f2 -d'-' > "$TMPDIR"/upstream_branches
-git branch --list -a "openshift/release-v0.*" | cut -f3 -d'/' | cut -f2 -d'v' | cut -f1,2 -d'.' >> "$TMPDIR"/midstream_branches
+git branch --list -a "upstream/release-1.*" | cut -f3 -d'/' | cut -f2 -d'-' > "$TMPDIR"/upstream_branches
+git branch --list -a "openshift/release-v1.*" | cut -f3 -d'/' | cut -f2 -d'v' | cut -f1,2 -d'.' >> "$TMPDIR"/midstream_branches
 
 sort -o "$TMPDIR"/midstream_branches "$TMPDIR"/midstream_branches
 sort -o "$TMPDIR"/upstream_branches "$TMPDIR"/upstream_branches


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

We are now having releases that are (for a long time) `1........`, so we change the script to reflect this