### PR TITLE
[release-v0.26] Do not use nightly for versioned branch

### DIFF
--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	exampleImage = "registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-print"
+	exampleImage = "registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-print"
 )
 
 func DataPlane_SinkTypes() *feature.FeatureSet {

--- a/test/rekt/resources/containersource/containersource.yaml
+++ b/test/rekt/resources/containersource/containersource.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: heartbeats
-        image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats
+        image: registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-heartbeats
         args:
         - --period=1
         env:

--- a/test/rekt/resources/containersource/containersource_test.go
+++ b/test/rekt/resources/containersource/containersource_test.go
@@ -47,7 +47,7 @@ func Example_min() {
 	//     spec:
 	//       containers:
 	//       - name: heartbeats
-	//         image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats
+	//         image: registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-heartbeats
 	//         args:
 	//         - --period=1
 	//         env:
@@ -106,7 +106,7 @@ func Example_full() {
 	//     spec:
 	//       containers:
 	//       - name: heartbeats
-	//         image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-heartbeats
+	//         image: registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-heartbeats
 	//         args:
 	//         - --period=1
 	//         env:

--- a/test/rekt/resources/eventlibrary/eventlibrary.yaml
+++ b/test/rekt/resources/eventlibrary/eventlibrary.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: library
-      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-library
+      image: registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-event-library
       imagePullPolicy: "IfNotPresent"
 
 ---

--- a/test/rekt/resources/eventlibrary/eventlibrary_test.go
+++ b/test/rekt/resources/eventlibrary/eventlibrary_test.go
@@ -24,7 +24,7 @@ import (
 
 func Example() {
 	images := map[string]string{
-		"registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-library": "gcr.io/knative-samples/helloworld-go",
+		"registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-event-library": "gcr.io/knative-samples/helloworld-go",
 	}
 	cfg := map[string]interface{}{
 		"name":      "foo",

--- a/test/rekt/resources/flaker/flaker.yaml
+++ b/test/rekt/resources/flaker/flaker.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: flaker
-      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-flaker
+      image: registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-event-flaker
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "K_SINK"

--- a/test/rekt/resources/flaker/flaker_test.go
+++ b/test/rekt/resources/flaker/flaker_test.go
@@ -24,7 +24,7 @@ import (
 
 func Example() {
 	images := map[string]string{
-		"registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-flaker": "gcr.io/knative-samples/helloworld-go",
+		"registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-event-flaker": "gcr.io/knative-samples/helloworld-go",
 	}
 	cfg := map[string]interface{}{
 		"name":      "foo",

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
@@ -24,7 +24,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: eventshub
-      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-eventshub
+      image: registry.ci.openshift.org/openshift/knative-v0.26.0:knative-eventing-test-eventshub
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "SYSTEM_NAMESPACE"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Manual change, to avoid conflicts wth "nightly".

Let's see that when we create a versioned branch, that we do some `sed` fu on patch files like:
https://github.com/openshift/knative-eventing/blob/main/openshift/patches/018-rekt-test-image-changes.patch#L22

So the `rekt test` images are than _matching_ the actual version....

for now... this is a manual change....

/assign @devguyio 