### PR TITLE
Patch patches to be versioned image strings

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -25,7 +25,7 @@ PATCH_DIR="openshift/patches"
 if [ -d "openshift/patches-${release}" ]; then
     PATCH_DIR="openshift/patches-${release}"
     # Update the nightly test images to actual versioned images
-    sed -i "s/knative-nightly:knative/knative-${release}:knative/g" openshift/patches/*.patch
+    sed -i "s/knative-nightly:knative/knative-${release}:knative/g" ${PATCH_DIR}/*.patch
 fi
 git apply $PATCH_DIR/*
 make RELEASE=$release generate-release

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -24,6 +24,8 @@ PATCH_DIR="openshift/patches"
 # Use release-specific patch dir if exists
 if [ -d "openshift/patches-${release}" ]; then
     PATCH_DIR="openshift/patches-${release}"
+    # Update the nightly test images to actual versioned images
+    sed -i "s/knative-nightly:knative/knative-${release}:knative/g" openshift/patches/*.patch
 fi
 git apply $PATCH_DIR/*
 make RELEASE=$release generate-release


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

when we create the RELEASE BRANCHES, we need the `nightly` test images to be replaced with versions.
For the REKT-TEST we have a handful of patches that override the `ko://` schema to use _real_ images.

On versioned branches, of course, we should not use `nightly`

/assign @devguyio 