### PR TITLE
Remove hard-coded 4.8 version

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -87,7 +87,7 @@ $image_deps
     owner: openshift-ci
     product: ocp
     timeout: 1h0m0s
-    version: "4.8"
+    version: "$openshift"
   steps:
     test:
     - as: test
@@ -108,7 +108,7 @@ $image_deps
     owner: openshift-ci
     product: ocp
     timeout: 1h0m0s
-    version: "4.8"
+    version: "$openshift"
   steps:
     test:
     - as: test
@@ -132,7 +132,7 @@ EOF
     owner: openshift-ci
     product: ocp
     timeout: 1h0m0s
-    version: "4.8"
+    version: "$openshift"
   cron: 0 */12 * * 1-5
   steps:
     test:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title, and tested here: https://github.com/openshift/release/pull/25439

/hold