### PR TITLE
Remove knative- from the release generator script

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -10,7 +10,7 @@ if [ "$release" == "ci" ]; then
     image_prefix="registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-"
     tag=""
 else
-    image_prefix="registry.ci.openshift.org/openshift/knative-${release}:knative-eventing-"
+    image_prefix="registry.ci.openshift.org/openshift/${release}:knative-eventing-"
     tag=""
 fi
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Upstream TAGs for releases are now called `knative-vX.Y.Z`, this leads to incorrect generated CI manifests, see here:

https://github.com/openshift/knative-eventing/blob/release-v1.2/openshift/release/knative-eventing-ci.yaml#L3353

Source is that we pass in the upstream tag, when we _automatically_ create the release, see:
https://github.com/openshift/knative-eventing/blob/main/openshift/release/mirror-upstream-branches.sh#L35

Fix: remove the version from the actual generator, and be explicit on the automation (mirror-update-branches).


For manually regenerating the bits, we than need to invoke the script like:

```bash
make RELEASE=knative-v1.0.0 generate-release
```

(as an example)


Once this is merged, we need to cherry pick it to following midstream branches:
* 1.0
* 1.1
* 1.2

and manually rin the `make RELEASE`, to fix the incorrect `knative-knative` string from the images :sweat_smile: 