### PR TITLE
Run Eventing midstream periodic jobs only on 4.9

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -3,7 +3,7 @@
 branch=${1-'knative-v0.6.0'}
 openshift=${2-'4.3'}
 promotion_disabled=${3-false}
-generate_continuous=true
+generate_continuous=${4-false}
 
 if [[ "$branch" == "knative-next" ]]; then
   promotion_name="knative-nightly"

--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -38,9 +38,9 @@ stage "Generating CI config files"
 CONFIG=$CONFIGDIR/openshift-knative-eventing-release-$VERSION
 PERIODIC_CONFIG=$PERIODIC_CONFIGDIR/openshift-knative-eventing-release-$VERSION-periodics.yaml
 CURDIR=$(dirname $0)
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.7 > ${CONFIG}__47.yaml
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.8 true > ${CONFIG}__48.yaml
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.9 true > ${CONFIG}__49.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.7 false false > ${CONFIG}__47.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.8 true false > ${CONFIG}__48.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.9 true true > ${CONFIG}__49.yaml
 
 # Append missing lines to the mirror file.
 if [[ "$VERSION" != "next" ]]; then


### PR DESCRIPTION
Running:
```
git checkout release-v1.2
make update-ci VERSION=knative-v1.2.0 OPENSHIFT=~/redhat/openshift/release/
```
produces no changes in `openshift/release` as expected.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>