### PR TITLE
[release-v1.2] adding generator for 4.10

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -41,6 +41,7 @@ CURDIR=$(dirname $0)
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.7 false false > ${CONFIG}__47.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.8 true false > ${CONFIG}__48.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.9 true true > ${CONFIG}__49.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.10 true true > ${CONFIG}__410.yaml
 
 # Append missing lines to the mirror file.
 if [[ "$VERSION" != "next" ]]; then


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title

NOTE: genrating periodics for 4.10 _as well_.

We might want to change that to _only_ 4.10 (instead of 4.9 as well)