### PR TITLE
[release-v1.0] backport of 6264

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -234,6 +234,9 @@ spec:
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
                     type: string
+              deadLetterSinkUri:
+                description: DeadLetterSinkURI is the resolved URI of the dead letter sink that will be used as a fallback when not specified by Triggers.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -3768,6 +3768,11 @@ in verbatim to the Channel CRD as Spec section.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="messaging.knative.dev/v1.ChannelTemplateSpecOption">ChannelTemplateSpecOption
+</h3>
+<p>
+<p>ChannelTemplateSpecOption is an optional function for ChannelTemplateSpec.</p>
+</p>
 <h3 id="messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec
 </h3>
 <p>

--- a/pkg/apis/messaging/v1/channel_template_types.go
+++ b/pkg/apis/messaging/v1/channel_template_types.go
@@ -30,3 +30,6 @@ type ChannelTemplateSpec struct {
 	// +optional
 	Spec *runtime.RawExtension `json:"spec,omitempty"`
 }
+
+// ChannelTemplateSpecOption is an optional function for ChannelTemplateSpec.
+type ChannelTemplateSpecOption func(*ChannelTemplateSpec) error

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -23,15 +23,18 @@ import (
 	"testing"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
-	"knative.dev/eventing/test/rekt/features/channel"
-	ch "knative.dev/eventing/test/rekt/resources/channel"
-	chimpl "knative.dev/eventing/test/rekt/resources/channel_impl"
-	"knative.dev/eventing/test/rekt/resources/subscription"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
+	"knative.dev/reconciler-test/pkg/manifest"
+
+	"knative.dev/eventing/test/rekt/features/channel"
+	ch "knative.dev/eventing/test/rekt/resources/channel"
+	chimpl "knative.dev/eventing/test/rekt/resources/channel_impl"
+	"knative.dev/eventing/test/rekt/resources/subscription"
 )
 
 // TestChannelConformance
@@ -180,6 +183,25 @@ func TestChannelDeadLetterSink(t *testing.T) {
 	)
 
 	env.Test(ctx, t, channel.DeadLetterSink())
+}
+
+// TestGenericChannelDeadLetterSink tests if the events that cannot be delivered end up in
+// the dead letter sink.
+func TestGenericChannelDeadLetterSink(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithSubscriber(ref, uri)
+	}
+	env.Test(ctx, t, channel.DeadLetterSinkGenericChannel(createSubscriberFn))
 }
 
 /*

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -23,6 +23,16 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/test"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/eventshub"
+
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
+	"knative.dev/reconciler-test/resources/svc"
+
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
+
+	"knative.dev/eventing/test/rekt/resources/channel"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/containersource"
 	"knative.dev/eventing/test/rekt/resources/delivery"
@@ -30,10 +40,6 @@ import (
 	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/source"
 	"knative.dev/eventing/test/rekt/resources/subscription"
-	"knative.dev/reconciler-test/pkg/eventshub"
-	"knative.dev/reconciler-test/pkg/eventshub/assert"
-	"knative.dev/reconciler-test/pkg/feature"
-	"knative.dev/reconciler-test/resources/svc"
 )
 
 func ChannelChain(length int) *feature.Feature {
@@ -92,10 +98,47 @@ func DeadLetterSink() *feature.Feature {
 		subscription.WithReply(svc.AsKReference(failer), ""),
 	))
 
-	f.Requirement("channel is ready", channel_impl.IsReady(name))
-	f.Requirement("containersource is ready", containersource.IsReady(cs))
+	f.Setup("channel is ready", channel_impl.IsReady(name))
+	f.Setup("containersource is ready", containersource.IsReady(cs))
 
-	f.Assert("dls receives events", assert.OnStore(sink).MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).AtLeast(1))
+	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(name, channel_impl.GVR()))
+
+	f.Assert("dls receives events", assert.OnStore(sink).
+		MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).
+		AtLeast(1),
+	)
+
+	return f
+}
+
+func DeadLetterSinkGenericChannel(createSubscriberFn func(ref *duckv1.KReference, uri string) manifest.CfgFn) *feature.Feature {
+	f := feature.NewFeature()
+	sink := feature.MakeRandomK8sName("sink")
+	failer := feature.MakeK8sNamePrefix("failer")
+	cs := feature.MakeRandomK8sName("containersource")
+	name := feature.MakeRandomK8sName("channel")
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+	f.Setup("install failing receiver", eventshub.Install(failer, eventshub.StartReceiver, eventshub.DropFirstN(1)))
+	f.Setup("install channel", channel.Install(name,
+		channel.WithTemplate(),
+		delivery.WithDeadLetterSink(svc.AsKReference(sink), "")),
+	)
+	f.Setup("install containersource", containersource.Install(cs, source.WithSink(channel.AsRef(name), "")))
+	f.Setup("install subscription", subscription.Install(feature.MakeRandomK8sName("subscription"),
+		subscription.WithChannel(channel.AsRef(name)),
+		createSubscriberFn(svc.AsKReference(failer), ""),
+	))
+
+	f.Setup("channel is ready", channel.IsReady(name))
+	f.Setup("containersource is ready", containersource.IsReady(cs))
+
+	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(name, channel.GVR()))
+
+	f.Assert("dls receives events", assert.OnStore(sink).
+		MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).
+		AtLeast(1),
+	)
 
 	return f
 }

--- a/test/rekt/resources/channel/channel.go
+++ b/test/rekt/resources/channel/channel.go
@@ -19,15 +19,21 @@ package channel
 import (
 	"context"
 	"embed"
+	"encoding/json"
+	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/eventing/test/rekt/resources/addressable"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
+
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/eventing/test/rekt/resources/addressable"
+	"knative.dev/eventing/test/rekt/resources/channel_impl"
 )
 
 //go:embed *.yaml
@@ -80,4 +86,44 @@ func AsRef(name string) *duckv1.KReference {
 		APIVersion: apiVersion,
 		Name:       name,
 	}
+}
+
+// WithTemplate adds channelTemplate to the Channel's config after apply the provided
+// options.
+func WithTemplate(options ...messagingv1.ChannelTemplateSpecOption) manifest.CfgFn {
+	return func(m map[string]interface{}) {
+		t := withTemplate(options...)
+		channelTemplate := map[string]interface{}{
+			"apiVersion": t.APIVersion,
+			"kind":       t.Kind,
+		}
+		m["channelTemplate"] = channelTemplate
+		if t.Spec != nil {
+			s := map[string]string{}
+			bytes, err := t.Spec.MarshalJSON()
+			if err != nil {
+				panic(fmt.Errorf("failed to marshal spec: %w", err))
+			}
+			if err := json.Unmarshal(bytes, &s); err != nil {
+				panic(fmt.Errorf("failed to unmarshal spec '%s': %v", bytes, err))
+			}
+			channelTemplate["spec"] = s
+		}
+	}
+}
+
+func withTemplate(options ...messagingv1.ChannelTemplateSpecOption) *messagingv1.ChannelTemplateSpec {
+	gvk := channel_impl.GVK()
+	t := &messagingv1.ChannelTemplateSpec{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       gvk.Kind,
+			APIVersion: gvk.GroupVersion().String(),
+		},
+	}
+	for _, opt := range options {
+		if err := opt(t); err != nil {
+			panic(err)
+		}
+	}
+	return t
 }


### PR DESCRIPTION
bringing #6264 to OCP midstream



FYI: https://github.com/openshift/knative-eventing/pull/1609  is already in...

