### PR TITLE
[release-v1.0] Adding regeneted manifest

### DIFF
--- a/openshift/release/knative-eventing-ci.yaml
+++ b/openshift/release/knative-eventing-ci.yaml
@@ -1510,6 +1510,9 @@ spec:
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
                     type: string
+              deadLetterSinkUri:
+                description: DeadLetterSinkURI is the resolved URI of the dead letter sink that will be used as a fallback when not specified by Triggers.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

In https://github.com/openshift/knative-eventing/pull/1655 I did forget to regenerate the CI manifests - and it (1655) was merged by accident...

 