### PR TITLE
Set TerminationGracePeriodSecond for wathola-sender to 300 seconds (#…

### DIFF
--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -30,6 +30,7 @@ var senderName = "wathola-sender"
 func (p *prober) deploySender() {
 	p.log.Info("Deploy sender deployment: ", senderName)
 	var replicas int32 = 1
+	var gracePeriodSeconds int64 = 300
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      senderName,
@@ -68,6 +69,7 @@ func (p *prober) deploySender() {
 							MountPath: p.config.ConfigMountPoint,
 						}},
 					}},
+					TerminationGracePeriodSeconds: &gracePeriodSeconds,
 				},
 			},
 		},


### PR DESCRIPTION
…6192)

* There may be blocking calls in the sender which can take longer than
the default period. This prevents the infinite loop from handling the
SIGTERM, resulting in not sending a Stop event.