### PR TITLE
Do not populare the Eventing CI files with testing bits

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -146,6 +146,10 @@ data:
 EOF
 }
 
+function configure_sugar_controller_testing {
+ oc apply -f test/config/sugar.yaml
+}
+
 function install_serverless(){
   header "Installing Serverless Operator"
   local operator_dir=/tmp/serverless-operator
@@ -183,6 +187,9 @@ function install_knative_eventing(){
   # Wait for 5 pods to appear first
   timeout_non_zero 900 '[[ $(oc get pods -n $EVENTING_NAMESPACE --no-headers | wc -l) -lt 5 ]]' || return 1
   wait_until_pods_running $EVENTING_NAMESPACE || return 1
+
+  # Apply the testing config for the sugar controller
+  configure_sugar_controller_testing
 
   # Assert that there are no images used that are not CI images (which should all be using the $INTERNAL_REGISTRY)
   # (except for the knative-eventing-operator)

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -17,9 +17,6 @@ fi
 # the core parts
 resolve_resources config/ $output_file $image_prefix $tag
 
-# Sugar testing configuration
-cat test/config/sugar.yaml >> $output_file
-
 # InMemoryChannel folders...
 # The root folder
 resolve_resources config/channels/in-memory-channel/ crd-channel-resolved.yaml $image_prefix $tag


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

For better "release artifact" yamls, we dont add test bits to our midstream manifests.


Was tested in:
https://github.com/openshift/knative-eventing/pull/1718