### PR TITLE
[release-v1.1] Set ARTIFACTS based on ARTIFACT_DIR provided in CI

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [[ -n "${ARTIFACT_DIR:-}" ]]; then
+  ARTIFACTS="${ARTIFACT_DIR}/build-${BUILD_NUMBER}"
+  export ARTIFACTS
+  mkdir -p "${ARTIFACTS}"
+fi
+
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
 export SYSTEM_NAMESPACE=$EVENTING_NAMESPACE
 export ZIPKIN_NAMESPACE=$EVENTING_NAMESPACE

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -n "${ARTIFACT_DIR:-}" ]]; then
+  BUILD_NUMBER=${BUILD_NUMBER:-$(head -c 128 < /dev/urandom | base64 | fold -w 8 | head -n 1)}
   ARTIFACTS="${ARTIFACT_DIR}/build-${BUILD_NUMBER}"
   export ARTIFACTS
   mkdir -p "${ARTIFACTS}"


### PR DESCRIPTION
The tests are using the ARTIFACTS dir to store JUnit results so they
should be available in the job report.