### PR TITLE
Allow more customization of ko resolve commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ test-reconciler:
 # Requires ko 0.2.0 or newer.
 test-images:
 	for img in $(TEST_IMAGES); do \
-		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf $$img ; \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B $$img ; \
 	done
 .PHONY: test-images
 
 test-image-single:
-	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf test/test_images/$(IMAGE)
+	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B test/test_images/$(IMAGE)
 .PHONY: test-image-single
 
 # Run make DOCKER_REPO_OVERRIDE=<your_repo> test-e2e-local if test images are available

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ CGO_ENABLED=0
 GOOS=linux
 CORE_IMAGES=$(shell find ./cmd -name main.go ! -path "./cmd/broker/*" ! -path "./cmd/mtbroker/*" | sed 's|/main.go||') ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate ./vendor/knative.dev/pkg/leaderelection/chaosduck
 TEST_IMAGES=$(shell find ./test/test_images -mindepth 1 -maxdepth 1 -type d) ./vendor/knative.dev/reconciler-test/cmd/eventshub
+TEST_IMAGE_TAG=latest
 KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
+KO_FLAGS=
 BRANCH=
 TEST=
 IMAGE=
@@ -42,12 +44,12 @@ test-reconciler:
 # Requires ko 0.2.0 or newer.
 test-images:
 	for img in $(TEST_IMAGES); do \
-		ko resolve --tags=latest -RBf $$img ; \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf $$img ; \
 	done
 .PHONY: test-images
 
 test-image-single:
-	ko resolve --tags=latest -RBf test/test_images/$(IMAGE)
+	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf test/test_images/$(IMAGE)
 .PHONY: test-image-single
 
 # Run make DOCKER_REPO_OVERRIDE=<your_repo> test-e2e-local if test images are available

--- a/openshift/patches/100-ko-baseimage.patch
+++ b/openshift/patches/100-ko-baseimage.patch
@@ -1,0 +1,8 @@
+diff --git a/.ko.yaml b/.ko.yaml
+index b1075a3cd..2f054a22c 100644
+--- a/.ko.yaml
++++ b/.ko.yaml
+@@ -1,2 +1,2 @@
+ # Use :nonroot base image for all containers
+-defaultBaseImage: gcr.io/distroless/static:nonroot
++defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
TEST_IMAGE_TAG allows for per-branch test image build, and KO_FLAGS allows for --platform (for multi-arch builds) and --sbom=none (for quay.io uploads).
