### PR TITLE
[release-v1.5] Patch broker sugar config on midstream

### DIFF
--- a/config/core/configmaps/sugar.yaml
+++ b/config/core/configmaps/sugar.yaml
@@ -24,33 +24,13 @@ metadata:
   annotations:
     knative.dev/example-checksum: "b05e6e70"
 data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # namespace-selector specifies a LabelSelector which
-    # determines which namespaces the Sugar Controller should operate upon
-    # Use an empty value to disable the feature (this is the default):
-    namespace-selector: ""
-
-    # Use an empty object to enable for all namespaces
-    namespace-selector: {}
-
-    # trigger-selector specifies a LabelSelector which
-    # determines which triggers the Sugar Controller should operate upon
-    # Use an empty value to disable the feature (this is the default):
-    trigger-selector: ""
-
-    # Use an empty object to enable for all triggers
-    trigger-selector: {}
+  namespace-selector: |
+    matchExpressions:
+    - key: "eventing.knative.dev/injection"
+      operator: "In"
+      values: ["enabled"]
+  trigger-selector: |
+    matchExpressions:
+    - key: "eventing.knative.dev/injection"
+      operator: "In"
+      values: ["enabled"]

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -3908,36 +3908,16 @@ metadata:
   annotations:
     knative.dev/example-checksum: "b05e6e70"
 data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # namespace-selector specifies a LabelSelector which
-    # determines which namespaces the Sugar Controller should operate upon
-    # Use an empty value to disable the feature (this is the default):
-    namespace-selector: ""
-
-    # Use an empty object to enable for all namespaces
-    namespace-selector: {}
-
-    # trigger-selector specifies a LabelSelector which
-    # determines which triggers the Sugar Controller should operate upon
-    # Use an empty value to disable the feature (this is the default):
-    trigger-selector: ""
-
-    # Use an empty object to enable for all triggers
-    trigger-selector: {}
+  namespace-selector: |
+    matchExpressions:
+    - key: "eventing.knative.dev/injection"
+      operator: "In"
+      values: ["enabled"]
+  trigger-selector: |
+    matchExpressions:
+    - key: "eventing.knative.dev/injection"
+      operator: "In"
+      values: ["enabled"]
 ---
 # Copyright 2018 The Knative Authors
 #

--- a/pkg/reconciler/sugar/trigger/trigger.go
+++ b/pkg/reconciler/sugar/trigger/trigger.go
@@ -57,11 +57,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *v1.Trigger) reconcile
 	if err != nil {
 		return fmt.Errorf("invalid label selector for triggers: %w", err)
 	}
-	if !selector.Matches(kubelabels.Set(t.GetLabels())) {
+
+	// For improved backwards compat. we check if we have the annotation as well
+	// With this, the actual value is configured on the config-sugar, for the annotation as well.
+	if selector.Matches(kubelabels.Set(t.GetLabels())) || selector.Matches(kubelabels.Set(t.GetAnnotations())) {
+		logging.FromContext(ctx).Debugf("Sugar Controller enabled for Trigger:%s in configmap 'config-sugar'", t.Name)
+	} else {
 		logging.FromContext(ctx).Debugf("Sugar Controller disabled for Trigger:%s in configmap 'config-sugar'", t.Name)
 		return nil
-	} else {
-		logging.FromContext(ctx).Debugf("Sugar Controller enabled for Trigger:%s in configmap 'config-sugar'", t.Name)
 	}
 
 	_, err = r.brokerLister.Brokers(t.Namespace).Get(t.Spec.Broker)


### PR DESCRIPTION
Following up on https://github.com/openshift/knative-eventing/pull/1849 - But for 1.5

We can decide if we want to patch and keep this behavior, or if for 1.5 (1.26) (or even 1.6/1.27) we want a proper `post-install` job (just for Openshift Serverless), that migrates the annotations to be labels.

But that's TBD...
