### PR TITLE
[main] Golang 1.18 bump and go-get command tweak

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.17
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,7 +7,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl httpd-tools
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Golang updates:

* Updating to golang-1.18, since upstream is now building with that. Similar PR from serving team: https://github.com/openshift/knative-serving/pull/1182
* Tweaking the `go get` command, similar to what serving team did in https://github.com/openshift/knative-serving/pull/1185 


 