### PR TITLE
Using Golang 1.18

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
 
 COPY . .
 RUN make install test-install

--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
 
 COPY . .
 RUN make install test-install


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Based on https://github.com/openshift/knative-eventing/pull/1807, updating the other `Dockerfile`s.... 
Since, https://github.com/openshift/knative-eventing/pull/1852 seems to be not relevant any more.

Big question: Is the `openshift/ci-operator/build-image/Dockerfile` no longer in use? 

/assign @aliok 
/assign @pierDipi 