### PR TITLE
Adding patch to keep sugar controller behavior

### DIFF
--- a/openshift/patches/patch_sugar_controller_for_backwards_compat.patch
+++ b/openshift/patches/patch_sugar_controller_for_backwards_compat.patch
@@ -1,0 +1,72 @@
+diff --git a/config/core/configmaps/sugar.yaml b/config/core/configmaps/sugar.yaml
+index 01747957b..2981df353 100644
+--- a/config/core/configmaps/sugar.yaml
++++ b/config/core/configmaps/sugar.yaml
+@@ -24,33 +24,13 @@ metadata:
+   annotations:
+     knative.dev/example-checksum: "62dfac6f"
+ data:
+-  _example: |
+-    ################################
+-    #                              #
+-    #    EXAMPLE CONFIGURATION     #
+-    #                              #
+-    ################################
+-    # This block is not actually functional configuration,
+-    # but serves to illustrate the available configuration
+-    # options and document them in a way that is accessible
+-    # to users that `kubectl edit` this config map.
+-    #
+-    # These sample configuration options may be copied out of
+-    # this example block and unindented to be in the data block
+-    # to actually change the configuration.
+-
+-    # namespace-selector specifies a LabelSelector which
+-    # determines which namespaces the Sugar Controller should operate upon
+-    # Use an empty value to disable the feature (this is the default):
+-    namespace-selector: ""
+-
+-    # Use an empty object as a string to enable for all namespaces
+-    namespace-selector: "{}"
+-
+-    # trigger-selector specifies a LabelSelector which
+-    # determines which triggers the Sugar Controller should operate upon
+-    # Use an empty value to disable the feature (this is the default):
+-    trigger-selector: ""
+-
+-    # Use an empty object as string to enable for all triggers
+-    trigger-selector: "{}"
++  namespace-selector: |
++    matchExpressions:
++    - key: "eventing.knative.dev/injection"
++      operator: "In"
++      values: ["enabled"]
++  trigger-selector: |
++    matchExpressions:
++    - key: "eventing.knative.dev/injection"
++      operator: "In"
++      values: ["enabled"]
+diff --git a/pkg/reconciler/sugar/trigger/trigger.go b/pkg/reconciler/sugar/trigger/trigger.go
+index 230ee79e7..527454619 100644
+--- a/pkg/reconciler/sugar/trigger/trigger.go
++++ b/pkg/reconciler/sugar/trigger/trigger.go
+@@ -57,13 +57,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *v1.Trigger) reconcile
+ 	if err != nil {
+ 		return fmt.Errorf("invalid label selector for triggers: %w", err)
+ 	}
+-	if !selector.Matches(kubelabels.Set(t.GetLabels())) {
++
++	// For improved backwards compat. we check if we have the annotation as well
++	// With this, the actual value is configured on the config-sugar, for the annotation as well.
++	if selector.Matches(kubelabels.Set(t.GetLabels())) || selector.Matches(kubelabels.Set(t.GetAnnotations())) {
++		logging.FromContext(ctx).Debugf("Sugar Controller enabled for Trigger:%s in configmap 'config-sugar'", t.Name)
++	} else {
+ 		logging.FromContext(ctx).Debugf("Sugar Controller disabled for Trigger:%s in configmap 'config-sugar'", t.Name)
+ 		return nil
+-	} else {
+-		logging.FromContext(ctx).Debugf("Sugar Controller enabled for Trigger:%s in configmap 'config-sugar'", t.Name)
+ 	}
+-
+ 	_, err = r.brokerLister.Brokers(t.Namespace).Get(t.Spec.Broker)
+ 
+ 	// If the resource doesn't exist, we'll create it.


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

similar to https://github.com/openshift/knative-eventing/pull/1856

But for `main`, or `release-next` 

At somepoint we can revisit this, and perhaps change the support of sugar controller to be removed/deprecated

