### PR TITLE
[release-v1.3] Regenerate release based on existing resources

### DIFF
--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -4406,7 +4406,7 @@ spec:
               value: "webhook"
         livenessProbe:
           <<: *probe
-          initialDelaySeconds: 20
+          initialDelaySeconds: 120
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.

--- a/openshift/release/artifacts/in-memory-channel.yaml
+++ b/openshift/release/artifacts/in-memory-channel.yaml
@@ -243,7 +243,7 @@ spec:
                 value: "webhook"
         livenessProbe:
           <<: *probe
-          initialDelaySeconds: 20
+          initialDelaySeconds: 120
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Midstream resources were out of sync, hence regenerating those with the `make RELEASE` target