### PR TITLE
[release-v1.7] Correct the upstream 1.7 release adjustments on midstream branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,8 @@ require (
 	k8s.io/apiserver v0.23.9
 	k8s.io/client-go v0.23.9
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	knative.dev/hack v0.0.0-20220815132133-e9a8475f4329
-	knative.dev/hack/schema v0.0.0-20220815132133-e9a8475f4329
+	knative.dev/hack v0.0.0-20220823124317-d35c718d592e
+	knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e
 	knative.dev/pkg v0.0.0-20220818004048-4a03844c0b15
 	knative.dev/reconciler-test v0.0.0-20220818122349-177f8264c28c
 	sigs.k8s.io/yaml v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,8 @@ require (
 	k8s.io/apiserver v0.23.9
 	k8s.io/client-go v0.23.9
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	knative.dev/hack v0.0.0-20220823124317-d35c718d592e
-	knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e
+	knative.dev/hack v0.0.0-20220823140917-8d1e4ccf9dc3
+	knative.dev/hack/schema v0.0.0-20220823140917-8d1e4ccf9dc3
 	knative.dev/pkg v0.0.0-20220818004048-4a03844c0b15
 	knative.dev/reconciler-test v0.0.0-20220818122349-177f8264c28c
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1225,10 +1225,10 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/hack v0.0.0-20220823124317-d35c718d592e h1:R5MDaTTA/mjF+7nADV0uML82B+rR9m2HQVZaSymUhoY=
-knative.dev/hack v0.0.0-20220823124317-d35c718d592e/go.mod h1:t/azP8I/Cygaw+87O7rkAPrNRjCelmtfSzWzu/9TM7I=
-knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e h1:vTyjV18NsK9L/VzHZe8z5P7SjdXDx1BO41wWv/+uLGI=
-knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
+knative.dev/hack v0.0.0-20220823140917-8d1e4ccf9dc3 h1:umaeMRecA0g5g48L9tnEAkTBIitr9eKWMyJYo9YttAA=
+knative.dev/hack v0.0.0-20220823140917-8d1e4ccf9dc3/go.mod h1:t/azP8I/Cygaw+87O7rkAPrNRjCelmtfSzWzu/9TM7I=
+knative.dev/hack/schema v0.0.0-20220823140917-8d1e4ccf9dc3 h1:4CBnt+DXNymX52r9zDgqgp3BCiKzF3+h7MwirVtKFDA=
+knative.dev/hack/schema v0.0.0-20220823140917-8d1e4ccf9dc3/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
 knative.dev/pkg v0.0.0-20220818004048-4a03844c0b15 h1:GNmzHVaUo3zoi/wtIN71LPQaWy6DdoYzmb+GIq2s4fw=
 knative.dev/pkg v0.0.0-20220818004048-4a03844c0b15/go.mod h1:YLjXbkQLlGHok+u0FLfMbBHFzY9WGu3GHhnrptoAy8I=
 knative.dev/reconciler-test v0.0.0-20220818122349-177f8264c28c h1:wWtcZ1ZyP+mXx4xQmcKzKyXkk/t07/iSq/jqhqxoyCM=

--- a/go.sum
+++ b/go.sum
@@ -1225,10 +1225,10 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/hack v0.0.0-20220815132133-e9a8475f4329 h1:/X969GuiLDMgb+tyx5qZDLxGhENkS3OLPj/VCSW+Ul0=
-knative.dev/hack v0.0.0-20220815132133-e9a8475f4329/go.mod h1:t/azP8I/Cygaw+87O7rkAPrNRjCelmtfSzWzu/9TM7I=
-knative.dev/hack/schema v0.0.0-20220815132133-e9a8475f4329 h1:rJJJk9dmXc6M6kUA+2GKv5BbFXQGd9fSodLzJFZYaKc=
-knative.dev/hack/schema v0.0.0-20220815132133-e9a8475f4329/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
+knative.dev/hack v0.0.0-20220823124317-d35c718d592e h1:R5MDaTTA/mjF+7nADV0uML82B+rR9m2HQVZaSymUhoY=
+knative.dev/hack v0.0.0-20220823124317-d35c718d592e/go.mod h1:t/azP8I/Cygaw+87O7rkAPrNRjCelmtfSzWzu/9TM7I=
+knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e h1:vTyjV18NsK9L/VzHZe8z5P7SjdXDx1BO41wWv/+uLGI=
+knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
 knative.dev/pkg v0.0.0-20220818004048-4a03844c0b15 h1:GNmzHVaUo3zoi/wtIN71LPQaWy6DdoYzmb+GIq2s4fw=
 knative.dev/pkg v0.0.0-20220818004048-4a03844c0b15/go.mod h1:YLjXbkQLlGHok+u0FLfMbBHFzY9WGu3GHhnrptoAy8I=
 knative.dev/reconciler-test v0.0.0-20220818122349-177f8264c28c h1:wWtcZ1ZyP+mXx4xQmcKzKyXkk/t07/iSq/jqhqxoyCM=

--- a/vendor/knative.dev/hack/release.sh
+++ b/vendor/knative.dev/hack/release.sh
@@ -107,7 +107,7 @@ export GITHUB_TOKEN=""
 # Convenience function to run the hub tool.
 # Parameters: $1..$n - arguments to hub.
 function hub_tool() {
-  gorun github.com/github/hub@v2.14.2 "$@"
+  go_run github.com/github/hub@v2.14.2 "$@"
 }
 
 # Shortcut to "git push" that handles authentication.

--- a/vendor/knative.dev/hack/release.sh
+++ b/vendor/knative.dev/hack/release.sh
@@ -107,7 +107,8 @@ export GITHUB_TOKEN=""
 # Convenience function to run the hub tool.
 # Parameters: $1..$n - arguments to hub.
 function hub_tool() {
-  go_run github.com/github/hub@v2.14.2 "$@"
+  # Pinned to SHA because of https://github.com/github/hub/issues/2517
+  go_run github.com/github/hub/v2@363513a "$@"
 }
 
 # Shortcut to "git push" that handles authentication.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1207,11 +1207,11 @@ k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/hack v0.0.0-20220823124317-d35c718d592e
+# knative.dev/hack v0.0.0-20220823140917-8d1e4ccf9dc3
 ## explicit; go 1.17
 knative.dev/hack
 knative.dev/hack/shell
-# knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e
+# knative.dev/hack/schema v0.0.0-20220823140917-8d1e4ccf9dc3
 ## explicit; go 1.15
 knative.dev/hack/schema/commands
 knative.dev/hack/schema/docs

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1207,11 +1207,11 @@ k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/hack v0.0.0-20220815132133-e9a8475f4329
+# knative.dev/hack v0.0.0-20220823124317-d35c718d592e
 ## explicit; go 1.17
 knative.dev/hack
 knative.dev/hack/shell
-# knative.dev/hack/schema v0.0.0-20220815132133-e9a8475f4329
+# knative.dev/hack/schema v0.0.0-20220823124317-d35c718d592e
 ## explicit; go 1.15
 knative.dev/hack/schema/commands
 knative.dev/hack/schema/docs


### PR DESCRIPTION
For release 1.7.0 in upstream, some things were simply missing.

Those were added in two PRs to the upstream branch:
* https://github.com/knative/eventing/pull/6493
* https://github.com/knative/eventing/pull/6495

This PR lands those changes (resulting in upstream 1.7.1) to our midstream 1.7 branch...

