### PR TITLE
[release-v1.5] Setting to 1.21 (matching ocp 4.8)

### DIFF
--- a/openshift/patches/005-k8s-min.patch
+++ b/openshift/patches/005-k8s-min.patch
@@ -1,13 +1,13 @@
 diff --git a/vendor/knative.dev/pkg/version/version.go b/vendor/knative.dev/pkg/version/version.go
-index 3cbd846ea..81b1ba46a 100644
+index c79f442de..b304f2b0a 100644
 --- a/vendor/knative.dev/pkg/version/version.go
 +++ b/vendor/knative.dev/pkg/version/version.go
 @@ -33,7 +33,7 @@ const (
  	// NOTE: If you are changing this line, please also update the minimum kubernetes
  	// version listed here:
  	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
--	defaultMinimumVersion = "v1.21.0"
-+	defaultMinimumVersion = "v1.19.0"
+-	defaultMinimumVersion = "v1.19.0"
++	defaultMinimumVersion = "v1.21.0"
  )
  
  func getMinimumVersion() string {

--- a/vendor/knative.dev/pkg/version/version.go
+++ b/vendor/knative.dev/pkg/version/version.go
@@ -33,7 +33,7 @@ const (
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
 	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
-	defaultMinimumVersion = "v1.19.0"
+	defaultMinimumVersion = "v1.21.0"
 )
 
 func getMinimumVersion() string {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

or 1.5 (aka 1.26 serverless), we are min at OCP 4.8 (aka k8s 1.21).


/hold 
(for feedback and reviews)