### PR TITLE
[release-v1.5] Fix scc drop issues

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -96,7 +96,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -96,7 +96,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -80,7 +80,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -77,7 +77,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -94,4 +94,4 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -96,7 +96,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -98,6 +98,6 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
 
       serviceAccountName: pingsource-mt-adapter

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -100,7 +100,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: https-webhook

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -61,5 +61,5 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
 

--- a/config/tools/appender/appender.yaml
+++ b/config/tools/appender/appender.yaml
@@ -34,4 +34,4 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL

--- a/config/tools/event-display/event-display.yaml
+++ b/config/tools/event-display/event-display.yaml
@@ -31,4 +31,4 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL

--- a/config/tools/heartbeats/heartbeats.yaml
+++ b/config/tools/heartbeats/heartbeats.yaml
@@ -33,7 +33,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
 
   sink:
     ref:

--- a/config/tools/recordevents/recordevents.yaml
+++ b/config/tools/recordevents/recordevents.yaml
@@ -43,4 +43,4 @@ spec:
         runAsNonRoot: true
         capabilities:
           drop:
-          - all
+          - ALL

--- a/config/tools/websocket-source/websocket-source.yaml
+++ b/config/tools/websocket-source/websocket-source.yaml
@@ -29,7 +29,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
 
   sink:
     ref:

--- a/openshift/release/artifacts/eventing-core.yaml
+++ b/openshift/release/artifacts/eventing-core.yaml
@@ -4076,7 +4076,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics
@@ -4184,7 +4184,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
 
       serviceAccountName: pingsource-mt-adapter
 ---
@@ -4451,7 +4451,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: https-webhook

--- a/openshift/release/artifacts/eventing-post-install.yaml
+++ b/openshift/release/artifacts/eventing-post-install.yaml
@@ -224,5 +224,5 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
 

--- a/openshift/release/artifacts/in-memory-channel.yaml
+++ b/openshift/release/artifacts/in-memory-channel.yaml
@@ -223,7 +223,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics
@@ -410,7 +410,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 ---
 # Copyright 2019 The Knative Authors
 #

--- a/openshift/release/artifacts/mt-channel-broker.yaml
+++ b/openshift/release/artifacts/mt-channel-broker.yaml
@@ -357,7 +357,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
 ---
 
@@ -483,7 +483,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
 ---
 
@@ -593,7 +593,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics


### PR DESCRIPTION
replacing `all` with `ALL`, since this is the only acceptable string check [here](https://github.com/kubernetes/kubernetes/blob/6dbec8e25592d47fc8a8269c86d4b5fa838d320b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#30) and [here](https://github.com/kubernetes/kubernetes/blob/6dbec8e25592d47fc8a8269c86d4b5fa838d320b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#L94)

Related to https://github.com/openshift-knative/serverless-operator/pull/1773#issuecomment-1286682842

Also, please see upstream https://github.com/knative/eventing/pull/6533