### PR TITLE
We are supporting min OCP 4.8, which matches to upstream k8s 1.21

### DIFF
--- a/openshift/patches/005-k8s-min.patch
+++ b/openshift/patches/005-k8s-min.patch
@@ -1,13 +1,13 @@
 diff --git a/vendor/knative.dev/pkg/version/version.go b/vendor/knative.dev/pkg/version/version.go
-index 39e34464b..c79f442de 100644
+index 32b818ecf..b304f2b0a 100644
 --- a/vendor/knative.dev/pkg/version/version.go
 +++ b/vendor/knative.dev/pkg/version/version.go
 @@ -33,7 +33,7 @@ const (
  	// NOTE: If you are changing this line, please also update the minimum kubernetes
  	// version listed here:
  	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
--	defaultMinimumVersion = "v1.22.0"
-+	defaultMinimumVersion = "v1.19.0"
+-	defaultMinimumVersion = "v1.23.0"
++	defaultMinimumVersion = "v1.21.0"
  )
  
  func getMinimumVersion() string {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title

