### PR TITLE
Fix tiny typo in release manual

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 The Openshift Knative Eventing release cut is mostly automated and requires only two manual steps for enabling the CI runs on the `openshift/release` repository.
 
-No manual creation of a midstream `release-v1.x` branch is needed. The nightly Jenkins job, does create a `release` branch, as soo as the upstream has created a new release tag. The code for this script is located in this [script](./openshift/release/mirror-upstream-branches.sh), which does mirror the upstream release tag to our midstream `release` branches.
+No manual creation of a midstream `release-v1.x` branch is needed. The nightly Jenkins job creates a `release` branch as soon as the upstream has created a new release tag. The code for this script is located in this [script](./openshift/release/mirror-upstream-branches.sh) and mirrors the upstream release tag to our midstream `release` branches.
 
 ## Enable CI for the release branch
 


### PR DESCRIPTION
Fix a tiny typo (and some wording) in the RELEASE.md:
`soo` -> `soon`