### PR TITLE
[release-v1.5] Decrease exportTraceLimit to 100

### DIFF
--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -48,7 +48,7 @@ const (
 	jobWaitInterval     = time.Second
 	jobWaitTimeout      = 10 * time.Minute
 	stepEventMsgPattern = "event #([0-9]+).*"
-	exportTraceLimit    = 1000
+	exportTraceLimit    = 100
 )
 
 // Verify will verify prober state after finished has been sent.


### PR DESCRIPTION
Exporting too many traces may lead to test suite timeouts and the root cause should be common and visible with fewer event traces.