### PR TITLE
Fix patch after upstream changes for security context

### DIFF
--- a/openshift/patches/018-rekt-test-image-changes.patch
+++ b/openshift/patches/018-rekt-test-image-changes.patch
@@ -46,18 +46,18 @@ index d59abd673..48faff01f 100644
  	//         args:
  	//         - --period=1
 diff --git a/test/rekt/resources/eventlibrary/eventlibrary.yaml b/test/rekt/resources/eventlibrary/eventlibrary.yaml
-index 7cd5e8e57..96777f69f 100644
+index f525ec977..384525bf3 100644
 --- a/test/rekt/resources/eventlibrary/eventlibrary.yaml
 +++ b/test/rekt/resources/eventlibrary/eventlibrary.yaml
-@@ -23,7 +23,7 @@ spec:
+@@ -29,7 +29,7 @@ spec:
    restartPolicy: "Never"
    containers:
      - name: library
 -      image: ko://knative.dev/eventing/test/test_images/event-library
 +      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-library
        imagePullPolicy: "IfNotPresent"
- 
- ---
+       {{ if .containerSecurityContext }}
+       securityContext:
 diff --git a/test/rekt/resources/eventlibrary/eventlibrary_test.go b/test/rekt/resources/eventlibrary/eventlibrary_test.go
 index ab948b642..d78921d84 100644
 --- a/test/rekt/resources/eventlibrary/eventlibrary_test.go
@@ -72,18 +72,18 @@ index ab948b642..d78921d84 100644
  	cfg := map[string]interface{}{
  		"name":      "foo",
 diff --git a/test/rekt/resources/flaker/flaker.yaml b/test/rekt/resources/flaker/flaker.yaml
-index 207c3d681..8821bb577 100644
+index 69aba2123..3b3e8effd 100644
 --- a/test/rekt/resources/flaker/flaker.yaml
 +++ b/test/rekt/resources/flaker/flaker.yaml
-@@ -23,7 +23,7 @@ spec:
+@@ -29,7 +29,7 @@ spec:
    restartPolicy: "Never"
    containers:
      - name: flaker
 -      image: ko://knative.dev/eventing/test/test_images/event-flaker
 +      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-event-flaker
        imagePullPolicy: "IfNotPresent"
-       env:
-         - name: "K_SINK"
+       {{ if .containerSecurityContext }}
+       securityContext:
 diff --git a/test/rekt/resources/flaker/flaker_test.go b/test/rekt/resources/flaker/flaker_test.go
 index bc33ccdc2..03b03a071 100644
 --- a/test/rekt/resources/flaker/flaker_test.go
@@ -98,13 +98,13 @@ index bc33ccdc2..03b03a071 100644
  	cfg := map[string]interface{}{
  		"name":      "foo",
 diff --git a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
-index da12b92a2..87cc044c4 100644
+index 2b8ad28d3..e34319f57 100644
 --- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
 +++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
-@@ -24,7 +24,7 @@ spec:
-   restartPolicy: "Never"
-   containers:
-     - name: eventshub
+@@ -47,7 +47,7 @@ spec:
+           {{ end }}
+         allowPrivilegeEscalation: {{ .containerSecurityContext.allowPrivilegeEscalation }}
+       {{ end }}
 -      image: {{ .image }}
 +      image: registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-test-eventshub
        imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
This is to make the nightly sync job pass. Last failure was https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing/615/console