### PR TITLE
Make sure we also new files, created out of the git-apply command

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -27,6 +27,8 @@ if [ -d "openshift/patches-${release}" ]; then
     # Update the nightly test images to actual versioned images
     sed -i "s/knative-nightly:knative/knative-${release}:knative/g" ${PATCH_DIR}/*.patch
 fi
-git apply $PATCH_DIR/*
+# Apply patches and also add new files, created by the patches
+git apply --index $PATCH_DIR/*
+
 make RELEASE=$release generate-release
 git commit -am ":fire: Apply carried patches."

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -25,7 +25,8 @@ git commit -m ":open_file_folder: Update openshift specific files."
 for p in openshift/patches/*
 do
  echo "Applying patch $p"
- git apply -v $p
+ # Apply patches and also add new files, created by the patches
+ git apply --index -v $p
 done
 
 make RELEASE=ci generate-release


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

We have a patch file that creates a new file, but currently our "create branch" scripts are not adding that newly created file to the tree, since it does `git apply`, like:

```
➜  eventing git:(xyz) git apply openshift/patches/022-openshift-serverless-view-eventing-configmaps.patch 
➜  eventing git:(xyz) ✗ gst
HEAD detached from upstream/main
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	config/openshift-serverless-view-eventing-configmaps.yaml

nothing added to commit but untracked files present (use "git add" to track)
```

With `--index` the file is added:

```
it apply --index openshift/patches/022-openshift-serverless-view-eventing-configmaps.patch
➜  eventing git:(xyz) ✗ gst
HEAD detached from upstream/main
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	new file:   config/openshift-serverless-view-eventing-configmaps.yaml

➜  eventing git:(xyz) ✗ 
```
