### PR TITLE
[main] Updating min version patch

### DIFF
--- a/openshift/patches/005-k8s-min.patch
+++ b/openshift/patches/005-k8s-min.patch
@@ -1,12 +1,12 @@
 diff --git a/vendor/knative.dev/pkg/version/version.go b/vendor/knative.dev/pkg/version/version.go
-index 32b818ecf..b304f2b0a 100644
+index dbf7daa69..b304f2b0a 100644
 --- a/vendor/knative.dev/pkg/version/version.go
 +++ b/vendor/knative.dev/pkg/version/version.go
 @@ -33,7 +33,7 @@ const (
  	// NOTE: If you are changing this line, please also update the minimum kubernetes
  	// version listed here:
  	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
--	defaultMinimumVersion = "v1.23.0"
+-	defaultMinimumVersion = "v1.24.0"
 +	defaultMinimumVersion = "v1.21.0"
  )
  


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Upstream bumped to 1.24 (from 1.23), so our tmp..... patch is being patched ... :dizzy: 